### PR TITLE
Convert from rspec to minitest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,14 @@
 require 'bundler/gem_tasks'
-require 'rspec/core/rake_task'
+require 'rake/testtask'
 
 desc "Run specs"
-RSpec::Core::RakeTask.new(:spec)
+Rake::TestTask.new do |t|
+    t.libs << "spec"
+    t.pattern = "spec/**/*_spec.rb"
+end
 
 desc "Run specs (default)"
-task :default => :spec
+task :default => :test
 
 desc "Remove protobuf definitions that have been compiled"
 task :clean do

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |gem|
   # Development dependencies
   #
   gem.add_development_dependency "rake"
-  gem.add_development_dependency "rspec"
-  gem.add_development_dependency "rspec-pride"
   gem.add_development_dependency "pry-nav"
   gem.add_development_dependency "simplecov"
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "timecop"
+  gem.add_development_dependency "minitest"
+  gem.add_development_dependency "minitest-spec-context"
 end

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "timecop"
   gem.add_development_dependency "minitest"
   gem.add_development_dependency "minitest-spec-context"
+  gem.add_development_dependency "mocha"
 end

--- a/spec/protobuf/active_record/columns_spec.rb
+++ b/spec/protobuf/active_record/columns_spec.rb
@@ -37,7 +37,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       context "when the column type is :date" do
         it "is true" do
-          User._protobuf_date_column?(:foo_date).should be_true
+          User._protobuf_date_column?(:foo_date).must_equal true
         end
       end
 
@@ -53,7 +53,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       context "when the column type is :datetime" do
         it "is true" do
-          User._protobuf_datetime_column?(:foo_datetime).should be_true
+          User._protobuf_datetime_column?(:foo_datetime).must_equal true
         end
       end
 
@@ -69,7 +69,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       context "when the column type is :time" do
         it "is true" do
-          User._protobuf_time_column?(:foo_time).should be_true
+          User._protobuf_time_column?(:foo_time).must_equal true
         end
       end
 
@@ -85,7 +85,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       context "when the column type is :timestamp" do
         it "is true" do
-          User._protobuf_timestamp_column?(:foo_timestamp).should be_true
+          User._protobuf_timestamp_column?(:foo_timestamp).must_equal true
         end
       end
 

--- a/spec/protobuf/active_record/columns_spec.rb
+++ b/spec/protobuf/active_record/columns_spec.rb
@@ -29,8 +29,8 @@ describe Protobuf::ActiveRecord::Columns do
   end
 
   context "column type predicates" do
-    before { User.stub(:_protobuf_column_types).and_return(Hash.new) }
-    after { User.unstub(:_protobuf_column_types) }
+    before { User.stubs(:_protobuf_column_types).returns(Hash.new) }
+    after { User.unstubs(:_protobuf_column_types) }
 
     describe "._protobuf_date_column?" do
       before { User._protobuf_column_types[:date] = [ :foo_date ] }

--- a/spec/protobuf/active_record/columns_spec.rb
+++ b/spec/protobuf/active_record/columns_spec.rb
@@ -43,7 +43,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       context "when the column type is not :date" do
         it "is false" do
-          User._protobuf_date_column?(:bar_date).should be_false
+          User._protobuf_date_column?(:bar_date).must_equal false
         end
       end
     end
@@ -59,7 +59,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       context "when the column type is not :datetime" do
         it "is false" do
-          User._protobuf_datetime_column?(:bar_datetime).should be_false
+          User._protobuf_datetime_column?(:bar_datetime).must_equal false
         end
       end
     end
@@ -75,7 +75,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       context "when the column type is not :time" do
         it "is false" do
-          User._protobuf_time_column?(:bar_time).should be_false
+          User._protobuf_time_column?(:bar_time).must_equal false
         end
       end
     end
@@ -91,7 +91,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       context "when the column type is not :timestamp" do
         it "is false" do
-          User._protobuf_timestamp_column?(:bar_timestamp).should be_false
+          User._protobuf_timestamp_column?(:bar_timestamp).must_equal false
         end
       end
     end

--- a/spec/protobuf/active_record/columns_spec.rb
+++ b/spec/protobuf/active_record/columns_spec.rb
@@ -30,7 +30,7 @@ describe Protobuf::ActiveRecord::Columns do
 
   context "column type predicates" do
     before { User.stubs(:_protobuf_column_types).returns(Hash.new) }
-    after { User.unstubs(:_protobuf_column_types) }
+    after { User.unstub(:_protobuf_column_types) }
 
     describe "._protobuf_date_column?" do
       before { User._protobuf_column_types[:date] = [ :foo_date ] }

--- a/spec/protobuf/active_record/columns_spec.rb
+++ b/spec/protobuf/active_record/columns_spec.rb
@@ -19,11 +19,11 @@ describe Protobuf::ActiveRecord::Columns do
       }
 
       it "maps columns by name" do
-        User._protobuf_columns.should eq expected_column_names
+        User._protobuf_columns.must_equal expected_column_names
       end
 
       it "maps column names by column type" do
-        User._protobuf_column_types.should eq expected_column_types
+        User._protobuf_column_types.must_equal expected_column_types
       end
     end
   end

--- a/spec/protobuf/active_record/persistence_spec.rb
+++ b/spec/protobuf/active_record/persistence_spec.rb
@@ -8,24 +8,24 @@ describe Protobuf::ActiveRecord::Persistence do
 
   describe ".create" do
     it "accepts a protobuf message" do
-      User.any_instance.should_receive(:save)
+      User.any_instance.expects(:save)
       User.create(proto)
     end
 
     it "accepts a hash" do
-      User.any_instance.should_receive(:save)
+      User.any_instance.expects(:save)
       User.create(user_attributes)
     end
   end
 
   describe ".create!" do
     it "accepts a protobuf message" do
-      User.any_instance.should_receive(:save!)
+      User.any_instance.expects(:save!)
       User.create!(proto)
     end
 
     it "accepts a hash" do
-      User.any_instance.should_receive(:save!)
+      User.any_instance.expects(:save!)
       User.create!(user_attributes)
     end
   end
@@ -46,24 +46,24 @@ describe Protobuf::ActiveRecord::Persistence do
 
   describe "#update_attributes" do
     it "accepts a protobuf message" do
-      User.any_instance.should_receive(:save)
+      User.any_instance.expects(:save)
       user.update_attributes(proto)
     end
 
     it "accepts a hash" do
-      User.any_instance.should_receive(:save)
+      User.any_instance.expects(:save)
       user.update_attributes(user_attributes)
     end
   end
 
   describe "#update_attributes!" do
     it "accepts a protobuf message" do
-      User.any_instance.should_receive(:save!)
+      User.any_instance.expects(:save!)
       user.update_attributes!(proto)
     end
 
     it "accepts a hash" do
-      User.any_instance.should_receive(:save!)
+      User.any_instance.expects(:save!)
       user.update_attributes!(user_attributes)
     end
   end

--- a/spec/protobuf/active_record/persistence_spec.rb
+++ b/spec/protobuf/active_record/persistence_spec.rb
@@ -35,12 +35,12 @@ describe Protobuf::ActiveRecord::Persistence do
 
     it "accepts a protobuf message" do
       user.assign_attributes(proto)
-      user.changed?.should be_true
+      user.changed?.must_equal true
     end
 
     it "accepts a hash" do
       user.assign_attributes(user_attributes)
-      user.changed?.should be_true
+      user.changed?.must_equal true
     end
   end
 

--- a/spec/protobuf/active_record/scope_spec.rb
+++ b/spec/protobuf/active_record/scope_spec.rb
@@ -95,7 +95,7 @@ describe Protobuf::ActiveRecord::Scope do
         let(:parser) { double('parser', :to_sym => :parser_to_sym) }
 
         it "passes the value to the parser" do
-          User.should_receive(:parser_to_sym).with([ "foo" ])
+          User.expects(:parser_to_sym).with([ "foo" ])
           User.parse_search_values(proto, :guid)
         end
       end
@@ -104,7 +104,7 @@ describe Protobuf::ActiveRecord::Scope do
         let(:parser) { double('parser') }
 
         it "passes the value to the parser" do
-          parser.should_receive(:call).with(["foo"])
+          parser.expects(:call).with(["foo"])
           User.parse_search_values(proto, :guid)
         end
       end

--- a/spec/protobuf/active_record/scope_spec.rb
+++ b/spec/protobuf/active_record/scope_spec.rb
@@ -21,11 +21,11 @@ describe Protobuf::ActiveRecord::Scope do
 
     it "builds scopes for searchable fields" do
       User.stub(:searchable_fields).and_return({ :email =>  :by_email })
-      User.search_scope(request).should eq User.by_email("foo@test.co")
+      User.search_scope(request).must_equal User.by_email("foo@test.co")
     end
 
     it "is chainable" do
-      User.limit(1).search_scope(request).order(:email).should eq User.limit(1).order(:email)
+      User.limit(1).search_scope(request).order(:email).must_equal User.limit(1).order(:email)
     end
 
     context "when a searchable field does not have a value" do
@@ -33,7 +33,7 @@ describe Protobuf::ActiveRecord::Scope do
 
       it "doesn't build a scope from that field" do
         User.stub(:searchable_fields).and_return({ :email =>  :by_email })
-        User.search_scope(request).should eq User.by_email("foo@test.co")
+        User.search_scope(request).must_equal User.by_email("foo@test.co")
       end
     end
 
@@ -51,28 +51,28 @@ describe Protobuf::ActiveRecord::Scope do
     context "when :scope is not defined" do
       it "defines the given field as searchable using the `by_[:field]` as the scope" do
         User.field_scope :guid
-        User.searchable_fields[:guid].should eq :by_guid
+        User.searchable_fields[:guid].must_equal :by_guid
       end
     end
 
     context "when :scope is defined" do
       it "defines the given field as searchable using the given :scope" do
         User.field_scope :guid, :scope => :custom_scope
-        User.searchable_fields[:guid].should eq :custom_scope
+        User.searchable_fields[:guid].must_equal :custom_scope
       end
     end
 
     context "when :parser is not defined" do
       it "doesn't define the given field as parseable" do
         User.field_scope :guid
-        User.searchable_field_parsers[:guid].should eq nil
+        User.searchable_field_parsers[:guid].must_equal nil
       end
     end
 
     context "when :parser is defined" do
       it "defines the given field as parseable using the given :parser" do
         User.field_scope :guid, :parser => :parser
-        User.searchable_field_parsers[:guid].should eq :parser
+        User.searchable_field_parsers[:guid].must_equal :parser
       end
     end
   end
@@ -83,7 +83,7 @@ describe Protobuf::ActiveRecord::Scope do
       proto = UserMessage.new(:email => "the.email@test.in")
 
       User.field_scope :email
-      User.parse_search_values(proto, :email).should eq ["the.email@test.in"]
+      User.parse_search_values(proto, :email).must_equal ["the.email@test.in"]
     end
 
     context "when a field parser is defined" do

--- a/spec/protobuf/active_record/scope_spec.rb
+++ b/spec/protobuf/active_record/scope_spec.rb
@@ -16,11 +16,11 @@ describe Protobuf::ActiveRecord::Scope do
     let(:request) { UserSearchMessage.new(:guid => ["foo"], :email => ["foo@test.co"]) }
 
     before {
-      User.stub(:searchable_field_parsers).and_return({ :email => proc { |val| val } })
+      User.stubs(:searchable_field_parsers).returns({ :email => proc { |val| val } })
     }
 
     it "builds scopes for searchable fields" do
-      User.stub(:searchable_fields).and_return({ :email =>  :by_email })
+      User.stubs(:searchable_fields).returns({ :email =>  :by_email })
       User.search_scope(request).must_equal User.by_email("foo@test.co")
     end
 
@@ -32,7 +32,7 @@ describe Protobuf::ActiveRecord::Scope do
       let(:request) { UserSearchMessage.new(:email => ["foo@test.co"]) }
 
       it "doesn't build a scope from that field" do
-        User.stub(:searchable_fields).and_return({ :email =>  :by_email })
+        User.stubs(:searchable_fields).returns({ :email =>  :by_email })
         User.search_scope(request).must_equal User.by_email("foo@test.co")
       end
     end
@@ -41,7 +41,7 @@ describe Protobuf::ActiveRecord::Scope do
       let(:request) { UserSearchMessage.new(:email => ["foo@test.co"]) }
 
       it "raises an exception" do
-        User.stub(:searchable_fields).and_return({ :email =>  :by_hullabaloo })
+        User.stubs(:searchable_fields).returns({ :email =>  :by_hullabaloo })
         expect { User.search_scope(request) }.to raise_exception(/Undefined scope :by_hullabaloo/)
       end
     end

--- a/spec/protobuf/active_record/scope_spec.rb
+++ b/spec/protobuf/active_record/scope_spec.rb
@@ -92,7 +92,7 @@ describe Protobuf::ActiveRecord::Scope do
       let(:proto) { UserSearchMessage.new(:guid => ["foo"]) }
 
       context "and the parser responds to :to_sym" do
-        let(:parser) { double('parser', :to_sym => :parser_to_sym) }
+        let(:parser) { stub('parser', :to_sym => :parser_to_sym) }
 
         it "passes the value to the parser" do
           User.expects(:parser_to_sym).with([ "foo" ])
@@ -101,7 +101,7 @@ describe Protobuf::ActiveRecord::Scope do
       end
 
       context "and the parser does not respond to :to_sym" do
-        let(:parser) { double('parser') }
+        let(:parser) { stub('parser') }
 
         it "passes the value to the parser" do
           parser.expects(:call).with(["foo"])

--- a/spec/protobuf/active_record/scope_spec.rb
+++ b/spec/protobuf/active_record/scope_spec.rb
@@ -42,7 +42,7 @@ describe Protobuf::ActiveRecord::Scope do
 
       it "raises an exception" do
         User.stubs(:searchable_fields).returns({ :email =>  :by_hullabaloo })
-        expect { User.search_scope(request) }.to raise_exception(/Undefined scope :by_hullabaloo/)
+        proc { User.search_scope(request) }.must_raise(/Undefined scope :by_hullabaloo/)
       end
     end
   end

--- a/spec/protobuf/active_record/scope_spec.rb
+++ b/spec/protobuf/active_record/scope_spec.rb
@@ -121,7 +121,7 @@ describe Protobuf::ActiveRecord::Scope do
         end
 
         proto = TheMessage.new(:the_enum_value => TheEnum::VALUE)
-        User.parse_search_values(proto, :the_enum_value)[0].should be 1
+        User.parse_search_values(proto, :the_enum_value)[0].must_equal 1
       end
     end
   end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -16,7 +16,7 @@ describe Protobuf::ActiveRecord::Serialization do
       before { User.stub(:_protobuf_date_column?).and_return(true) }
 
       it "converts the given value to an integer" do
-        User._protobuf_convert_attributes_to_fields(:foo_date, date).should eq integer
+        User._protobuf_convert_attributes_to_fields(:foo_date, date).must_equal integer
       end
     end
 
@@ -27,7 +27,7 @@ describe Protobuf::ActiveRecord::Serialization do
       before { User.stub(:_protobuf_datetime_column?).and_return(true) }
 
       it "converts the given value to an integer" do
-        User._protobuf_convert_attributes_to_fields(:foo_datetime, datetime).should eq integer
+        User._protobuf_convert_attributes_to_fields(:foo_datetime, datetime).must_equal integer
       end
     end
 
@@ -38,7 +38,7 @@ describe Protobuf::ActiveRecord::Serialization do
       before { User.stub(:_protobuf_time_column?).and_return(true) }
 
       it "converts the given value to an integer" do
-        User._protobuf_convert_attributes_to_fields(:foo_time, time).should eq integer
+        User._protobuf_convert_attributes_to_fields(:foo_time, time).must_equal integer
       end
     end
 
@@ -49,7 +49,7 @@ describe Protobuf::ActiveRecord::Serialization do
       before { User.stub(:_protobuf_timestamp_column?).and_return(true) }
 
       it "converts the given value to an integer" do
-        User._protobuf_convert_attributes_to_fields(:foo_timestamp, timestamp).should eq integer
+        User._protobuf_convert_attributes_to_fields(:foo_timestamp, timestamp).must_equal integer
       end
     end
 
@@ -57,7 +57,7 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:value) { "Foo" }
 
       it "returns the given value" do
-        User._protobuf_convert_attributes_to_fields(:foo, value).should eq value
+        User._protobuf_convert_attributes_to_fields(:foo, value).must_equal value
       end
     end
   end
@@ -108,12 +108,12 @@ describe Protobuf::ActiveRecord::Serialization do
 
     context "given options" do
       it "merges them with protobuf field options" do
-        User._protobuf_field_options.should eq options
+        User._protobuf_field_options.must_equal options
       end
     end
 
     it "returns the protobuf message for this object" do
-      User.protobuf_message.should eq protobuf_message
+      User.protobuf_message.must_equal protobuf_message
     end
   end
 
@@ -127,27 +127,27 @@ describe Protobuf::ActiveRecord::Serialization do
       context "when options has :only" do
         it "only returns the given field(s)" do
           fields = user._filter_field_attributes(:only => :name).should
-          fields.should eq [ :name ]
+          fields.must_equal [ :name ]
         end
       end
 
       context "when options has :except" do
         it "returns all except the given field(s)" do
           fields = user._filter_field_attributes(:except => :name).should
-          fields.should eq [ :guid, :email, :email_domain, :password ]
+          fields.must_equal [ :guid, :email, :email_domain, :password ]
         end
       end
     end
 
     describe "#_filtered_fields" do
       it "returns protobuf fields" do
-        user._filtered_fields.should eq [ :guid, :name, :email, :email_domain, :password ]
+        user._filtered_fields.must_equal [ :guid, :name, :email, :email_domain, :password ]
       end
 
       context "given :deprecated => false" do
         it "filters all deprecated fields" do
           fields = user._filtered_fields(:deprecated => false).should
-          fields.should eq [ :guid, :name, :email, :password ]
+          fields.must_equal [ :guid, :name, :email, :password ]
         end
       end
     end
@@ -159,7 +159,7 @@ describe Protobuf::ActiveRecord::Serialization do
         before { User.protobuf_message(protobuf_message, options) }
 
         it "returns the class's protobuf field options" do
-          User.allocate._normalize_options({}).should eq options
+          User.allocate._normalize_options({}).must_equal options
         end
       end
 
@@ -168,7 +168,7 @@ describe Protobuf::ActiveRecord::Serialization do
 
         it "merges them with the class's protobuf field options" do
           normalized_options = User.allocate._normalize_options(options)
-          normalized_options[:only].should eq options[:only]
+          normalized_options[:only].must_equal options[:only]
         end
       end
 
@@ -177,7 +177,7 @@ describe Protobuf::ActiveRecord::Serialization do
 
         it "ensures that :except exists" do
           normalized_options = User.allocate._normalize_options(options)
-          normalized_options[:except].should eq []
+          normalized_options[:except].must_equal []
         end
       end
 
@@ -188,7 +188,7 @@ describe Protobuf::ActiveRecord::Serialization do
 
         it "ensures that :only exists" do
           normalized_options = User.allocate._normalize_options(options)
-          normalized_options[:only].should eq []
+          normalized_options[:only].must_equal []
         end
       end
     end
@@ -212,7 +212,7 @@ describe Protobuf::ActiveRecord::Serialization do
         }
 
         it "gets the field from the transformer" do
-          user.fields_from_record.should eq fields_from_record
+          user.fields_from_record.must_equal fields_from_record
         end
       end
 
@@ -220,7 +220,7 @@ describe Protobuf::ActiveRecord::Serialization do
         let(:fields_from_record) { { :guid => user.guid, :name => user.name, :email => user.email, :email_domain => nil, :password => nil } }
 
         it "returns a hash of protobuf fields that this object has getters for" do
-          user.fields_from_record.should eq fields_from_record
+          user.fields_from_record.must_equal fields_from_record
         end
 
         it "converts attributes values for protobuf messages" do
@@ -245,7 +245,7 @@ describe Protobuf::ActiveRecord::Serialization do
         before { user.stub(:fields_from_record).and_return(proto_hash) }
 
         it "intializes a new protobuf message with attributes from #to_proto_hash" do
-          user.to_proto.should eq proto
+          user.to_proto.must_equal proto
         end
       end
 

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -13,7 +13,7 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:date) { Date.current }
       let(:integer) { date.to_time.to_i }
 
-      before { User.stub(:_protobuf_date_column?).and_return(true) }
+      before { User.stubs(:_protobuf_date_column?).returns(true) }
 
       it "converts the given value to an integer" do
         User._protobuf_convert_attributes_to_fields(:foo_date, date).must_equal integer
@@ -24,7 +24,7 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:datetime) { DateTime.current }
       let(:integer) { datetime.to_time.to_i }
 
-      before { User.stub(:_protobuf_datetime_column?).and_return(true) }
+      before { User.stubs(:_protobuf_datetime_column?).returns(true) }
 
       it "converts the given value to an integer" do
         User._protobuf_convert_attributes_to_fields(:foo_datetime, datetime).must_equal integer
@@ -35,7 +35,7 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:time) { Time.current }
       let(:integer) { time.to_time.to_i }
 
-      before { User.stub(:_protobuf_time_column?).and_return(true) }
+      before { User.stubs(:_protobuf_time_column?).returns(true) }
 
       it "converts the given value to an integer" do
         User._protobuf_convert_attributes_to_fields(:foo_time, time).must_equal integer
@@ -46,7 +46,7 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:timestamp) { Time.current }
       let(:integer) { timestamp.to_time.to_i }
 
-      before { User.stub(:_protobuf_timestamp_column?).and_return(true) }
+      before { User.stubs(:_protobuf_timestamp_column?).returns(true) }
 
       it "converts the given value to an integer" do
         User._protobuf_convert_attributes_to_fields(:foo_timestamp, timestamp).must_equal integer
@@ -84,7 +84,7 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:callable) { lambda { |proto| nil } }
 
       before {
-        User.stub(:_protobuf_field_transformers).and_return(Hash.new)
+        User.stubs(:_protobuf_field_transformers).returns(Hash.new)
         User.field_from_record :account_id, callable
       }
 
@@ -208,7 +208,7 @@ describe Protobuf::ActiveRecord::Serialization do
         let(:transformer) { { :email_domain => lambda { |record| record.email.split('@').last } } }
 
         before {
-          User.stub(:_protobuf_field_transformers).and_return(transformer)
+          User.stubs(:_protobuf_field_transformers).returns(transformer)
         }
 
         it "gets the field from the transformer" do
@@ -224,7 +224,7 @@ describe Protobuf::ActiveRecord::Serialization do
         end
 
         it "converts attributes values for protobuf messages" do
-          user.stub(:_protobuf_convert_attributes_to_fields)
+          user.stubs(:_protobuf_convert_attributes_to_fields)
           user.fields_from_record
         end
       end
@@ -242,7 +242,7 @@ describe Protobuf::ActiveRecord::Serialization do
         let(:proto) { protobuf_message.new(proto_hash) }
         let(:proto_hash) { { :name => "foo" } }
 
-        before { user.stub(:fields_from_record).and_return(proto_hash) }
+        before { user.stubs(:fields_from_record).returns(proto_hash) }
 
         it "intializes a new protobuf message with attributes from #to_proto_hash" do
           user.to_proto.must_equal proto

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -126,14 +126,14 @@ describe Protobuf::ActiveRecord::Serialization do
     describe "#_filter_field_attributes" do
       context "when options has :only" do
         it "only returns the given field(s)" do
-          fields = user._filter_field_attributes(:only => :name).should
+          fields = user._filter_field_attributes(:only => :name)
           fields.must_equal [ :name ]
         end
       end
 
       context "when options has :except" do
         it "returns all except the given field(s)" do
-          fields = user._filter_field_attributes(:except => :name).should
+          fields = user._filter_field_attributes(:except => :name)
           fields.must_equal [ :guid, :email, :email_domain, :password ]
         end
       end
@@ -146,7 +146,7 @@ describe Protobuf::ActiveRecord::Serialization do
 
       context "given :deprecated => false" do
         it "filters all deprecated fields" do
-          fields = user._filtered_fields(:deprecated => false).should
+          fields = user._filtered_fields(:deprecated => false)
           fields.must_equal [ :guid, :name, :email, :password ]
         end
       end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -232,7 +232,7 @@ describe Protobuf::ActiveRecord::Serialization do
       context "given options with :include" do
         it "adds the given field to the list of serialized fields" do
           fields = user.fields_from_record(:include => :token)
-          fields.include?(:token).should be_true
+          fields.include?(:token).must_equal true
         end
       end
     end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -76,7 +76,7 @@ describe Protobuf::ActiveRecord::Serialization do
 
     context "when the given converter is not callable" do
       it "raises an exception" do
-        expect { User.field_from_record :name, nil }.to raise_exception(Protobuf::ActiveRecord::FieldTransformerError)
+        proc { User.field_from_record :name, nil }.must_raise(Protobuf::ActiveRecord::FieldTransformerError)
       end
     end
 
@@ -253,7 +253,7 @@ describe Protobuf::ActiveRecord::Serialization do
         let(:user) { UnconfiguredUser.new }
 
         it "raises an exception" do
-          expect { user.to_proto }.to raise_exception(Protobuf::ActiveRecord::MessageNotDefined)
+          proc { user.to_proto }.must_raise(Protobuf::ActiveRecord::MessageNotDefined)
         end
       end
     end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -69,7 +69,7 @@ describe Protobuf::ActiveRecord::Serialization do
       before { User.field_from_record :first_name, :extract_first_name }
 
       it "creates a callable method object from the converter" do
-        User.should_receive(:extract_first_name)
+        User.expects(:extract_first_name)
         User._protobuf_field_transformers[:first_name].call(1)
       end
     end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -102,7 +102,7 @@ describe Protobuf::ActiveRecord::Serialization do
 
     context "given a value" do
       it "defines #to_proto" do
-        User.allocate.should respond_to :to_proto
+        User.allocate.must_respond_to :to_proto
       end
     end
 

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -18,7 +18,7 @@ describe Protobuf::ActiveRecord::Transformation do
     end
 
     it "includes attributes that aren't fields, but have attribute transformers" do
-      User.stub(:_protobuf_attribute_transformers).and_return({ :account_id => :fetch_account_id })
+      User.stubs(:_protobuf_attribute_transformers).returns({ :account_id => :fetch_account_id })
       attribute_fields = User._filter_attribute_fields(proto)
       attribute_fields.has_key?(:account_id).must_equal true
     end
@@ -34,7 +34,7 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:date) { Date.current }
       let(:value) { date.to_time.to_i }
 
-      before { User.stub(:_protobuf_date_column?).and_return(true) }
+      before { User.stubs(:_protobuf_date_column?).returns(true) }
 
       it "converts the given value to a Date object" do
         User._protobuf_convert_fields_to_attributes(:foo_date, value).must_equal date
@@ -45,7 +45,7 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:datetime) { DateTime.current }
       let(:value) { datetime.to_i }
 
-      before { User.stub(:_protobuf_datetime_column?).and_return(true) }
+      before { User.stubs(:_protobuf_datetime_column?).returns(true) }
 
       it "converts the given value to a DateTime object" do
         User._protobuf_convert_fields_to_attributes(:foo_datetime, value).should be_a(DateTime)
@@ -60,7 +60,7 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:time) { Time.current }
       let(:value) { time.to_i }
 
-      before { User.stub(:_protobuf_time_column?).and_return(true) }
+      before { User.stubs(:_protobuf_time_column?).returns(true) }
 
       it "converts the given value to a Time object" do
         User._protobuf_convert_fields_to_attributes(:foo_time, value).should be_a(Time)
@@ -75,7 +75,7 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:time) { Time.current }
       let(:value) { time.to_i }
 
-      before { User.stub(:_protobuf_timestamp_column?).and_return(true) }
+      before { User.stubs(:_protobuf_timestamp_column?).returns(true) }
 
       it "converts the given value to a Time object" do
         User._protobuf_convert_fields_to_attributes(:foo_time, value).should be_a(Time)
@@ -106,7 +106,7 @@ describe Protobuf::ActiveRecord::Transformation do
     context "when a transformer is a callable that returns nil" do
       before do
         transformers = User._protobuf_attribute_transformers
-        User.stub(:_protobuf_attribute_transformers).and_return(
+        User.stubs(:_protobuf_attribute_transformers).returns(
           {:account_id => lambda { |proto| nil }}.merge(transformers)
         )
       end
@@ -120,7 +120,7 @@ describe Protobuf::ActiveRecord::Transformation do
     context "when a transformer is a callable that returns a value" do
       before do
         transformers = User._protobuf_attribute_transformers
-        User.stub(:_protobuf_attribute_transformers).and_return(
+        User.stubs(:_protobuf_attribute_transformers).returns(
           {:account_id => lambda { |proto| 1 }}.merge(transformers)
         )
       end
@@ -133,7 +133,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
     context "when a transformer is not defined for the attribute" do
       before {
-        User.stub(:_protobuf_convert_fields_to_attributes) do |key, value|
+        User.stubs(:_protobuf_convert_fields_to_attributes) do |key, value|
           value
         end
       }
@@ -167,7 +167,7 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:callable) { lambda { |proto| nil } }
 
       before {
-        User.stub(:_protobuf_attribute_transformers).and_return(Hash.new)
+        User.stubs(:_protobuf_attribute_transformers).returns(Hash.new)
         User.attribute_from_proto :account_id, callable
       }
 

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -9,7 +9,7 @@ describe Protobuf::ActiveRecord::Transformation do
   describe "._filter_attribute_fields" do
     it "includes fields that have values" do
       attribute_fields = User._filter_attribute_fields(proto)
-      attribute_fields[:email].should eq proto_hash[:email]
+      attribute_fields[:email].must_equal proto_hash[:email]
     end
 
     it "filters repeated fields" do
@@ -37,7 +37,7 @@ describe Protobuf::ActiveRecord::Transformation do
       before { User.stub(:_protobuf_date_column?).and_return(true) }
 
       it "converts the given value to a Date object" do
-        User._protobuf_convert_fields_to_attributes(:foo_date, value).should eq date
+        User._protobuf_convert_fields_to_attributes(:foo_date, value).must_equal date
       end
     end
 
@@ -90,7 +90,7 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:value) { "Foo" }
 
       it "returns the given value" do
-        User._protobuf_convert_fields_to_attributes(:foo, value).should eq value
+        User._protobuf_convert_fields_to_attributes(:foo, value).must_equal value
       end
     end
   end
@@ -99,7 +99,7 @@ describe Protobuf::ActiveRecord::Transformation do
     context "when a transformer is defined for the attribute" do
       it "transforms the field value" do
         attribute_fields = User.attributes_from_proto(proto)
-        attribute_fields[:first_name].should eq user_attributes[:first_name]
+        attribute_fields[:first_name].must_equal user_attributes[:first_name]
       end
     end
 
@@ -113,7 +113,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
       it "does not set the attribute" do
         attribute_fields = User.attributes_from_proto(proto)
-        attribute_fields.should eq user_attributes
+        attribute_fields.must_equal user_attributes
       end
     end
 
@@ -127,7 +127,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
       it "sets the attribute" do
         attribute_fields = User.attributes_from_proto(proto)
-        attribute_fields.should eq user_attributes.merge(:account_id => 1)
+        attribute_fields.must_equal user_attributes.merge(:account_id => 1)
       end
     end
 
@@ -140,7 +140,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
       it "converts the field value" do
         attribute_fields = User.attributes_from_proto(proto)
-        attribute_fields.should eq user_attributes
+        attribute_fields.must_equal user_attributes
       end
     end
   end
@@ -183,7 +183,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
     it "initializes a new Date object from the value" do
       Timecop.freeze(Date.current) do
-        User.convert_int64_to_date(int64).should eq date
+        User.convert_int64_to_date(int64).must_equal date
       end
     end
   end
@@ -196,7 +196,7 @@ describe Protobuf::ActiveRecord::Transformation do
       Timecop.freeze(DateTime.current) do
         expected_datetime = Time.at(datetime.to_i)
         converted_datetime = User.convert_int64_to_datetime(int64)
-        converted_datetime.should eq expected_datetime
+        converted_datetime.must_equal expected_datetime
       end
     end
   end

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -14,7 +14,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
     it "filters repeated fields" do
       attribute_fields = User._filter_attribute_fields(proto)
-      attribute_fields.has_key?(:tags).should be_false
+      attribute_fields.has_key?(:tags).must_equal false
     end
 
     it "includes attributes that aren't fields, but have attribute transformers" do

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -48,7 +48,7 @@ describe Protobuf::ActiveRecord::Transformation do
       before { User.stubs(:_protobuf_datetime_column?).returns(true) }
 
       it "converts the given value to a DateTime object" do
-        User._protobuf_convert_fields_to_attributes(:foo_datetime, value).should be_a(DateTime)
+        User._protobuf_convert_fields_to_attributes(:foo_datetime, value).must_be_instance_of(DateTime)
       end
 
       it "converts the given value to a DateTime object of the same value" do
@@ -63,7 +63,7 @@ describe Protobuf::ActiveRecord::Transformation do
       before { User.stubs(:_protobuf_time_column?).returns(true) }
 
       it "converts the given value to a Time object" do
-        User._protobuf_convert_fields_to_attributes(:foo_time, value).should be_a(Time)
+        User._protobuf_convert_fields_to_attributes(:foo_time, value).must_be_instance_of(Time)
       end
 
       it "converts the given value to a Time object of the same value" do
@@ -78,7 +78,7 @@ describe Protobuf::ActiveRecord::Transformation do
       before { User.stubs(:_protobuf_timestamp_column?).returns(true) }
 
       it "converts the given value to a Time object" do
-        User._protobuf_convert_fields_to_attributes(:foo_time, value).should be_a(Time)
+        User._protobuf_convert_fields_to_attributes(:foo_time, value).must_be_instance_of(Time)
       end
 
       it "converts the given value to a Time object of the same value" do

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -159,7 +159,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
     context "when the given transformer is not callable" do
       it "raises an exception" do
-        expect { User.attribute_from_proto :name, nil }.to raise_exception(Protobuf::ActiveRecord::AttributeTransformerError)
+        proc { User.attribute_from_proto :name, nil }.must_raise(Protobuf::ActiveRecord::AttributeTransformerError)
       end
     end
 

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -52,7 +52,7 @@ describe Protobuf::ActiveRecord::Transformation do
       end
 
       it "converts the given value to a DateTime object of the same value" do
-        User._protobuf_convert_fields_to_attributes(:foo_datetime, value).should be_within(1).of(datetime)
+        User._protobuf_convert_fields_to_attributes(:foo_datetime, value).must_be_close_to datetime, 1
       end
     end
 
@@ -67,7 +67,7 @@ describe Protobuf::ActiveRecord::Transformation do
       end
 
       it "converts the given value to a Time object of the same value" do
-        User._protobuf_convert_fields_to_attributes(:foo_time, value).should be_within(1).of(time)
+        User._protobuf_convert_fields_to_attributes(:foo_time, value).must_be_close_to time, 1
       end
     end
 
@@ -82,7 +82,7 @@ describe Protobuf::ActiveRecord::Transformation do
       end
 
       it "converts the given value to a Time object of the same value" do
-        User._protobuf_convert_fields_to_attributes(:foo_timestamp, value).should be_within(1).of(time)
+        User._protobuf_convert_fields_to_attributes(:foo_timestamp, value).must_be_close_to time, 1
       end
     end
 
@@ -207,7 +207,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
     it "initializes a new Time object from the value" do
       Timecop.freeze(Time.current) do
-        User.convert_int64_to_time(int64).should be_within(1).of(time)
+        User.convert_int64_to_time(int64).must_be_close_to time, 1
       end
     end
   end

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -152,7 +152,7 @@ describe Protobuf::ActiveRecord::Transformation do
       before { User.attribute_from_proto :first_name, :extract_first_name }
 
       it "creates a callable method object from the converter" do
-        User.should_receive(:extract_first_name)
+        User.expects(:extract_first_name)
         User._protobuf_attribute_transformers[:first_name].call(1)
       end
     end
@@ -214,7 +214,7 @@ describe Protobuf::ActiveRecord::Transformation do
 
   describe "#attributes_from_proto" do
     it "gets attributes from the given protobuf message" do
-      User.should_receive(:attributes_from_proto).with(proto)
+      User.expects(:attributes_from_proto).with(proto)
       user.attributes_from_proto(proto)
     end
   end

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -20,12 +20,12 @@ describe Protobuf::ActiveRecord::Transformation do
     it "includes attributes that aren't fields, but have attribute transformers" do
       User.stub(:_protobuf_attribute_transformers).and_return({ :account_id => :fetch_account_id })
       attribute_fields = User._filter_attribute_fields(proto)
-      attribute_fields.has_key?(:account_id).should be_true
+      attribute_fields.has_key?(:account_id).must_equal true
     end
 
     it "includes fields that aren't attributes, but have attribute transformers" do
       attribute_fields = User._filter_attribute_fields(proto)
-      attribute_fields.has_key?(:password).should be_true
+      attribute_fields.has_key?(:password).must_equal true
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'bundler'
 require 'minitest/spec'
 require 'minitest/autorun'
 
+require 'mocha'
+
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'bundler'
 require 'minitest/spec'
 require 'minitest/autorun'
 
-require 'mocha'
+require 'mocha/setup'
 
 require 'simplecov'
 SimpleCov.start do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 require 'rubygems'
 require 'bundler'
 
+require 'minitest/spec'
+require 'minitest/autorun'
+
 require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'


### PR DESCRIPTION
I'm not very familiar with this stuff. This is about as far as I've gotten with this. Sorry its not finished.

If you want I can squash all of these commits into one.

Here is the rake output ->
(in /Users/sshaw/code/protobuf-activerecord)

**\* Mocha deprecation warning: Change `require 'mocha'` to `require 'mocha/setup'`.

-- create_table(:users)
   -> 0.0047s
-- initialize_schema_migrations_table()
   -> 0.0030s
Coverage report generated for RSpec to /Users/sshaw/code/protobuf-activerecord/coverage. 213 / 403 LOC (52.85%) covered.
Run options: --seed 39590
# Running tests:

...............................E.......................[WARNING] UserMessage#email_domain field usage is deprecated.
[WARNING] UserMessage#email_domain field usage is deprecated.
..[WARNING] UserMessage#email_domain field usage is deprecated.
[WARNING] UserMessage#email_domain field usage is deprecated.
...................F...

Finished tests in 0.117135s, 682.9726 tests/s, 648.8240 assertions/s.

  1) Error:
Protobuf::ActiveRecord::Scope::.search_scope::when a searchable field uses a non-existant scope#test_0001_raises an exception:
TypeError: class or module required
    (eval):4:in `must_raise'
    /Users/sshaw/code/protobuf-activerecord/spec/protobuf/active_record/scope_spec.rb:45:in`block (4 levels) in <top (required)>'

  2) Failure:
Protobuf::ActiveRecord::Transformation::.attributes_from_proto::when a transformer is not defined for the attribute#test_0001_converts the field value [/Users/sshaw/code/protobuf-activerecord/spec/protobuf/active_record/transformation_spec.rb:143]:
--- expected
+++ actual
@@ -1 +1 @@
-{:first_name=>"foo", :last_name=>"bar", :email=>"foo@test.co"}
+{:first_name=>"foo", :last_name=>"bar", :email=>nil}

80 tests, 76 assertions, 1 failures, 1 errors, 0 skips
rake aborted!
Command failed with status (1): [ruby -I"lib:spec" -I"/usr/local/Cellar/ruby/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib" "/usr/local/Cellar/ruby/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/rake_test_loader.rb" "spec/*_/__spec.rb" ]

Tasks: TOP => default => test
(See full trace by running task with --trace)
