### PR TITLE
Ensure DB connections are checked in

### DIFF
--- a/lib/protobuf-activerecord.rb
+++ b/lib/protobuf-activerecord.rb
@@ -13,6 +13,7 @@ end
 
 require 'protobuf/active_record/config'
 require 'protobuf/active_record/model'
+require 'protobuf/active_record/service_filters'
 require 'protobuf/active_record/version'
 
 module Protobuf

--- a/lib/protobuf/active_record/railtie.rb
+++ b/lib/protobuf/active_record/railtie.rb
@@ -8,6 +8,10 @@ module Protobuf
           include Protobuf::ActiveRecord::Model if Protobuf::ActiveRecord.config.autoload
         end
       end
+
+      ActiveSupport.on_load(:protobuf_rpc_service) do
+        include Protobuf::ActiveRecord::ServiceFilters
+      end
     end
   end
 end

--- a/lib/protobuf/active_record/service_filters.rb
+++ b/lib/protobuf/active_record/service_filters.rb
@@ -1,0 +1,17 @@
+module Protobuf
+  module ActiveRecord
+    module ServiceFilters
+      extend ::ActiveSupport::Concern
+
+      included do
+        around_filter :_protobuf_active_record_with_connection
+      end
+
+      def _protobuf_active_record_with_connection
+        ::ActiveRecord::Base.connection_pool.with_connection do
+          yield
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Using PB's around service filters, wrap each request in an AR `with_connection` call so that connections are checked in and out with each RPC request. This will ensure that DB connections are checked in after each RPC request and (hopefully) make PB::AR more compatible with Rails 4 (which no longer ensures connections are checked in for you).

@localshred, is this the best way to hook into the service filters? Alternatively, I can use the `on_inherit` hook to add filters to each service class, but this seems more efficient, assuming it will work as I'm expecting it to.

// @abrandoned, @brianstien
