### PR TITLE
Allow attributes to be set to nil

### DIFF
--- a/lib/protobuf/active_record/transformation.rb
+++ b/lib/protobuf/active_record/transformation.rb
@@ -101,16 +101,13 @@ module Protobuf
         #
         def attribute_from_proto(attribute, *args, &block)
           options = args.extract_options!
-          transformation = args.first || block
+          symbol_or_block = args.first || block
 
-          if transformation.is_a?(Symbol)
-            callable = lambda { |value| self.__send__(transformation, value) }
+          if symbol_or_block.is_a?(Symbol)
+            callable = lambda { |value| self.__send__(symbol_or_block, value) }
           else
-            callable = transformation
-          end
-
-          unless callable.respond_to?(:call)
-            raise AttributeTransformerError
+            raise AttributeTransformerError unless symbol_or_block.respond_to?(:call)
+            callable = symbol_or_block
           end
 
           transformer = ::Protobuf::ActiveRecord::Transformer.new(callable, options)

--- a/lib/protobuf/active_record/transformer.rb
+++ b/lib/protobuf/active_record/transformer.rb
@@ -1,0 +1,22 @@
+module Protobuf
+  module ActiveRecord
+    class Transformer
+      attr_accessor :callable, :options
+
+      def initialize(callable, options = {})
+        @callable = callable
+        @options = options
+      end
+
+      def call(proto)
+        callable.call(proto)
+      end
+
+      def nullify?(proto)
+        return false unless options[:nullify_on]
+
+        proto.field?(:nullify) && proto.nullify.include?(options[:nullify_on].to_s)
+      end
+    end
+  end
+end

--- a/lib/protobuf/active_record/transformer.rb
+++ b/lib/protobuf/active_record/transformer.rb
@@ -14,8 +14,12 @@ module Protobuf
 
       def nullify?(proto)
         return false unless options[:nullify_on]
+        if proto.field?(:nullify) && proto.nullify.is_a?(Array)
+          ::Protobuf::Logging.logger.warn "Message: #{proto.class} is not compatible with :nullify_on option"
+          return false
+        end
 
-        proto.field?(:nullify) && proto.nullify.include?(options[:nullify_on].to_s)
+        proto.nullify.include?(options[:nullify_on].to_s)
       end
     end
   end

--- a/lib/protobuf/active_record/transformer.rb
+++ b/lib/protobuf/active_record/transformer.rb
@@ -14,7 +14,7 @@ module Protobuf
 
       def nullify?(proto)
         return false unless options[:nullify_on]
-        if proto.field?(:nullify) && proto.nullify.is_a?(Array)
+        unless proto.field?(:nullify) && proto.nullify.is_a?(Array)
           ::Protobuf::Logging.logger.warn "Message: #{proto.class} is not compatible with :nullify_on option"
           return false
         end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -135,20 +135,20 @@ describe Protobuf::ActiveRecord::Serialization do
       context "when options has :except" do
         it "returns all except the given field(s)" do
           fields = user._filter_field_attributes(:except => :name)
-          expect(fields).to eq [ :guid, :email, :email_domain, :password ]
+          expect(fields).to eq [ :guid, :email, :email_domain, :password, :nullify ]
         end
       end
     end
 
     describe "#_filtered_fields" do
       it "returns protobuf fields" do
-        expect(user._filtered_fields).to eq [ :guid, :name, :email, :email_domain, :password ]
+        expect(user._filtered_fields).to eq [ :guid, :name, :email, :email_domain, :password, :nullify ]
       end
 
       context "given :deprecated => false" do
         it "filters all deprecated fields" do
           fields = user._filtered_fields(:deprecated => false)
-          expect(fields).to eq [ :guid, :name, :email, :password ]
+          expect(fields).to eq [ :guid, :name, :email, :password, :nullify ]
         end
       end
     end
@@ -205,7 +205,7 @@ describe Protobuf::ActiveRecord::Serialization do
       }
 
       context "when a transformer is defined for the field" do
-        let(:fields_from_record) { { :guid => user.guid, :name => user.name, :email => user.email, :email_domain => 'test.co', :password => nil } }
+        let(:fields_from_record) { { :guid => user.guid, :name => user.name, :email => user.email, :email_domain => 'test.co', :password => nil, :nullify => nil } }
         let(:transformer) { { :email_domain => lambda { |record| record.email.split('@').last } } }
 
         before {
@@ -218,7 +218,7 @@ describe Protobuf::ActiveRecord::Serialization do
       end
 
       context "when a transformer is not defined for the field" do
-        let(:fields_from_record) { { :guid => user.guid, :name => user.name, :email => user.email, :email_domain => nil, :password => nil } }
+        let(:fields_from_record) { { :guid => user.guid, :name => user.name, :email => user.email, :email_domain => nil, :password => nil, :nullify => nil } }
 
         it "returns a hash of protobuf fields that this object has getters for" do
           expect(user.fields_from_record).to eq fields_from_record

--- a/spec/protobuf/active_record/transformer_spec.rb
+++ b/spec/protobuf/active_record/transformer_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe ::Protobuf::ActiveRecord::Transformer do
+  let(:callable) { lambda { |proto| proto.name } }
+  let(:proto) { ::UserMessage.new(:name => 'test', :nullify => ['name']) }
+  let(:options) { {} }
+
+  subject { described_class.new(callable, options) }
+
+  describe '#call' do
+    it 'calls the callable' do
+      result = subject.call(proto)
+      expect(result).to eq('test')
+    end
+  end
+
+  describe '#nullify?' do
+    context 'no nullify_on set' do
+      it 'returns false' do
+        expect(subject.nullify?(proto)).to eq(false)
+      end
+    end
+
+    context 'nullify_on name' do
+      let(:options) { { :nullify_on => :name } }
+
+      context 'invalid message' do
+        let(:proto) { ::UserSearchMessage.new }
+
+        it 'returns false' do
+          expect(subject.nullify?(proto)).to eq(false)
+        end
+      end
+
+      context 'valid message' do
+        it 'returns true' do
+          expect(subject.nullify?(proto)).to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,9 @@ require 'support/db'
 require 'support/models'
 require 'support/protobuf'
 
+# Silence protobuf's logger
+::Protobuf::Logging.logger.level = ::Logger::FATAL
+
 RSpec.configure do |config|
   # Turn deprecation warnings into errors with full backtrace.
   config.raise_errors_for_deprecations!

--- a/spec/support/definitions/user.proto
+++ b/spec/support/definitions/user.proto
@@ -4,6 +4,7 @@ message UserMessage {
   optional string email        = 3;
   optional string email_domain = 4 [deprecated = true];
   optional string password     = 5;
+  repeated string nullify      = 6;
 }
 
 message UserSearchMessage {

--- a/spec/support/protobuf/user.pb.rb
+++ b/spec/support/protobuf/user.pb.rb
@@ -20,6 +20,7 @@ class UserMessage
   optional :string, :email, 3
   optional :string, :email_domain, 4, :deprecated => true
   optional :string, :password, 5
+  repeated :string, :nullify, 6
 end
 
 class UserSearchMessage


### PR DESCRIPTION
This adds logic to check a repeated string field called 'nullify'
on incoming proto messages.

For direct attributes, if there is an attribute with the same name
as an attribute specified in the nullify field, this attribute will be
set to nil.

For transformed attributes there is now an option when the transformer
is declared that will specify a name in the nullify field to inspect.
If the our key is in the nullify array of an incoming proto, the
transformer will set the transformed attribute to nil.
