### PR TITLE
Check message vs message class separately

### DIFF
--- a/lib/protobuf/active_record/transformation.rb
+++ b/lib/protobuf/active_record/transformation.rb
@@ -110,6 +110,13 @@ module Protobuf
             callable = symbol_or_block
           end
 
+          if options[:nullify_on]
+            field = protobuf_message.get_field(:nullify)
+            unless field && field.is_a?(::Protobuf::Field::StringField) && field.repeated?
+              ::Protobuf::Logging.logger.warn "Message: #{protobuf_message} is not compatible with :nullify_on option"
+            end
+          end
+
           transformer = ::Protobuf::ActiveRecord::Transformer.new(callable, options)
           _protobuf_attribute_transformers[attribute.to_sym] = transformer
         end

--- a/lib/protobuf/active_record/transformer.rb
+++ b/lib/protobuf/active_record/transformer.rb
@@ -14,11 +14,6 @@ module Protobuf
 
       def nullify?(proto)
         return false unless options[:nullify_on]
-        field = proto.class.get_field(:nullify)
-        unless field && field.is_a?(::Protobuf::Field::StringField) && field.rule == :repeated
-          ::Protobuf::Logging.logger.warn "Message: #{proto.class} is not compatible with :nullify_on option"
-          return false
-        end
         return false unless proto.field?(:nullify) && proto.nullify.is_a?(Array)
 
         proto.nullify.include?(options[:nullify_on].to_s)

--- a/lib/protobuf/active_record/transformer.rb
+++ b/lib/protobuf/active_record/transformer.rb
@@ -14,10 +14,12 @@ module Protobuf
 
       def nullify?(proto)
         return false unless options[:nullify_on]
-        unless proto.field?(:nullify) && proto.nullify.is_a?(Array)
+        field = proto.class.get_field(:nullify)
+        unless field && field.is_a?(::Protobuf::Field::StringField) && field.rule == :repeated
           ::Protobuf::Logging.logger.warn "Message: #{proto.class} is not compatible with :nullify_on option"
           return false
         end
+        return false unless proto.field?(:nullify) && proto.nullify.is_a?(Array)
 
         proto.nullify.include?(options[:nullify_on].to_s)
       end


### PR DESCRIPTION
Sorry this is like my third try at this, but I am fairly certain this is the behavior we are looking for in regards to the warning message.

Checking `field?` checks the value of the field.  The warning needs to check the message structure, not the presence/absence of the value.

The fixes a bug where the warning message would be thrown on regular update calls when the value of the nullify field was not set, which is fine and should not throw a warning.