### PR TITLE
Replace deprecated has_field? with field? to support Protobuf 4.0

### DIFF
--- a/lib/protobuf/active_record/transformation.rb
+++ b/lib/protobuf/active_record/transformation.rb
@@ -30,7 +30,7 @@ module Protobuf
           fields = proto.to_hash
           fields.select! do |key, value|
             field = proto.class.get_field(key, true)
-            proto.has_field?(key) && !field.repeated?
+            proto.field?(key) && !field.repeated?
           end
 
           filtered_attributes = _filtered_attributes + _protobuf_nested_attributes

--- a/spec/support/models/user.rb
+++ b/spec/support/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
   attribute_from_proto :password, lambda { |proto| proto.password! }
 
   def self.extract_first_name(proto)
-    if proto.has_field?(:name)
+    if proto.field?(:name)
       names = proto.name.split(" ")
       first_name = names.first
     end
@@ -20,7 +20,7 @@ class User < ActiveRecord::Base
   end
 
   def self.extract_last_name(proto)
-    if proto.has_field?(:name)
+    if proto.field?(:name)
       names = proto.name.split(" ")
       names.shift # Drop the first name
       last_name = names.join(" ")


### PR DESCRIPTION
https://github.com/liveh2o/protobuf-activerecord/issues/18

Note: This doesn't resolve the `attributes_from_proto` usage which doesn't have an explicit end of life.

```
DEPRECATION WARNING: UserMessage#email_domain field usage is deprecated. (called from attributes_from_proto at protobuf-activerecord/lib/protobuf/active_record/transformation.rb:174)
```