### PR TITLE
make the column type values a Set instead of an Array as O(n) vs O(1)…

### DIFF
--- a/lib/protobuf/active_record/columns.rb
+++ b/lib/protobuf/active_record/columns.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'active_support/concern'
 
 module Protobuf
@@ -46,7 +47,7 @@ module Protobuf
             return if _protobuf_mapped_columns?
 
             @_protobuf_columns = {}
-            @_protobuf_column_types = Hash.new { |h,k| h[k] = [] }
+            @_protobuf_column_types = ::Hash.new { |h,k| h[k] = ::Set.new }
 
             columns.map do |column|
               @_protobuf_columns[column.name.to_sym] = column

--- a/lib/protobuf/active_record/transformer.rb
+++ b/lib/protobuf/active_record/transformer.rb
@@ -15,6 +15,7 @@ module Protobuf
       def nullify?(proto)
         return false unless options[:nullify_on]
         return false unless proto.field?(:nullify) && proto.nullify.is_a?(Array)
+        return false if proto.nullify.empty?
 
         proto.nullify.include?(options[:nullify_on].to_s)
       end

--- a/spec/protobuf/active_record/columns_spec.rb
+++ b/spec/protobuf/active_record/columns_spec.rb
@@ -12,7 +12,7 @@ describe Protobuf::ActiveRecord::Columns do
 
       let(:expected_column_types) {
         User.columns.inject({}) do |hash, column|
-          hash[column.type.to_sym] ||= []
+          hash[column.type.to_sym] ||= ::Set.new
           hash[column.type.to_sym] << column.name.to_sym
           hash
         end


### PR DESCRIPTION
… on include check

in profiling this code on JRuby most of the "loss" of time is from the `include?` check on the columns ... as a db table gets wider the serialization slows down in a non-linear fashion (it should be linear dependent on the number of columns that have values), but that is not what occurs.

it all comes down to the `include?` check on an array (which is O(n), where n is the number of columns) vs an `include?` check on a Set (which is O(1), always)

this resolves the issue by making the column types a Set

@liveh2o @film42 (thought you might like to be tagged @film42 as we are both working through profiling tasks)
