### PR TITLE
optimize serialization and fix ordered spec array

### DIFF
--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -23,17 +23,17 @@ module Protobuf
         def _protobuf_convert_attributes_to_fields(key, value)
           case
           when value.nil? then
-            return value
+            value
           when _protobuf_date_column?(key) then
-            return value.to_time.to_i
+            value.to_time.to_i
           when _protobuf_datetime_column?(key) then
-            return value.to_i
+            value.to_i
           when _protobuf_time_column?(key) then
-            return value.to_i
+            value.to_i
           when _protobuf_timestamp_column?(key) then
-            return value.to_i
+            value.to_i
           else
-            return value
+            value
           end
         end
 

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -135,20 +135,20 @@ describe Protobuf::ActiveRecord::Serialization do
       context "when options has :except" do
         it "returns all except the given field(s)" do
           fields = user._filter_field_attributes(:except => :name)
-          expect(fields).to eq [ :guid, :email, :email_domain, :password, :nullify ]
+          expect(fields).to match_array([ :guid, :email, :email_domain, :password, :nullify ])
         end
       end
     end
 
     describe "#_filtered_fields" do
       it "returns protobuf fields" do
-        expect(user._filtered_fields).to eq [ :guid, :name, :email, :email_domain, :password, :nullify ]
+        expect(user._filtered_fields).to match_array([ :guid, :name, :email, :email_domain, :password, :nullify ])
       end
 
       context "given :deprecated => false" do
         it "filters all deprecated fields" do
           fields = user._filtered_fields(:deprecated => false)
-          expect(fields).to eq [ :guid, :name, :email, :password, :nullify ]
+          expect(fields).to match_array([ :guid, :name, :email, :password, :nullify ])
         end
 
         context 'and :include => :email_domain' do


### PR DESCRIPTION
couple of optimizations that make a considerable difference in "real-world" serialization

1. cache hits on 'respond_to?' ... AR respond_to? is overridden so a set of patterns will hit if 'method_missing' (or some other incantation) will derive the method at runtime ... this is very expensive; caching the "hits" speeds 10_000 serializations by about 10 seconds

2. use `concat` instead of `+=` as we don't want/need to allocate a new array ... also selectively run `flatten` as we only need it when dealing with `:include` and other options and it is the most expensive Array operation to run ... saves 2-3 seconds over 10_000 serializations

3. cache deprecated and non-deprecated fields as they don't need to be dynamically calculated each time a serialization is run ... another second

4. use a `while` loop over the `each` ... this optimization is not necessarily significant, but not carrying through a block (scope) is faster over 10_000 iterations (200-500ms) ... particularly on JRuby 9k ... if one place deserves to be "hyper-optimized" it's serialization code so I threw it in

also removed stack local copies in a few cases (such as the fields_for_record call) as we don't use them and can insert directly into the returned hash

Overall these optimizations saved 12-15 seconds on serialization of 10_000 records that originally took 37 seconds to serialize

@liveh2o @film42 @brianstien 