### PR TITLE
Date serialization timezone shift bug fix

### DIFF
--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -25,7 +25,7 @@ module Protobuf
           when value.nil? then
             value
           when _protobuf_date_column?(key) then
-            value.to_time.to_i
+            value.to_time(:utc).to_i
           when _protobuf_datetime_column?(key) then
             value.to_i
           when _protobuf_time_column?(key) then

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -10,8 +10,8 @@ describe Protobuf::ActiveRecord::Serialization do
 
   describe "._protobuf_convert_attributes_to_fields" do
     context "when the column type is :date" do
-      let(:date) { Date.current }
-      let(:integer) { date.to_time.to_i }
+      let(:date) { Date.new(2015, 10, 1) }
+      let(:integer) { 1_443_657_600 }
 
       before { allow(User).to receive(:_protobuf_date_column?).and_return(true) }
 


### PR DESCRIPTION
### summary

When a date field is serialized, it is converted to an epoch using local timezone. This behavior could make dates in responses incorrect. _This is a bug whose fix could have unintended impact._

### explanation

Dates are represented as `int64` epoch times. The conversion from epoch to `Date` [here](https://github.com/liveh2o/protobuf-activerecord/blob/master/lib/protobuf/active_record/transformation.rb#L162) converts the int to a time, then shifts it to `.utc` time before converting to a `Date`. This is correct behavior.

When serializing a date to an epoch [here](https://github.com/liveh2o/protobuf-activerecord/blob/master/lib/protobuf/active_record/serialization.rb#L28), it extracts epoch from a timezone offset time. _This may not be the same date that was stored._

### examples

_I set my local timezone to "Kyiv - Ukraine" for this example_

![image](https://cloud.githubusercontent.com/assets/12796/10489302/2f0a9758-72a5-11e5-8ad8-7059c473f6bd.png)

__The date portion of the epoch is wrong!__
![image](https://cloud.githubusercontent.com/assets/12796/10489341/60ada1ec-72a5-11e5-8e09-b8dca7166a7a.png)

__With the proposed fix...__
![image](https://cloud.githubusercontent.com/assets/12796/10489360/75d2078e-72a5-11e5-9cc4-18b92be601a1.png)

The date portion is correct.
![image](https://cloud.githubusercontent.com/assets/12796/10489381/8aacf240-72a5-11e5-8d4d-16c102551448.png)


