### PR TITLE
Bdewitt/micro optimizations

### DIFF
--- a/lib/protobuf/active_record/columns.rb
+++ b/lib/protobuf/active_record/columns.rb
@@ -40,8 +40,7 @@ module Protobuf
 
         # :nodoc:
         def _protobuf_date_column?(key)
-          column_types = _protobuf_column_types[:date]
-          !column_types.nil? && column_types.include?(key)
+          _protobuf_column_types[:date].include?(key)
         end
 
         # :nodoc:
@@ -51,8 +50,7 @@ module Protobuf
 
         # :nodoc:
         def _protobuf_datetime_column?(key)
-          column_types = _protobuf_column_types[:datetime]
-          !column_types.nil? && column_types.include?(key)
+          _protobuf_column_types[:datetime].include?(key)
         end
 
         # Map out the columns for future reference on type conversion
@@ -89,14 +87,12 @@ module Protobuf
 
         # :nodoc:
         def _protobuf_time_column?(key)
-          column_types = _protobuf_column_types[:time]
-          !column_types.nil? && column_types.include?(key)
+          _protobuf_column_types[:time].include?(key)
         end
 
         # :nodoc:
         def _protobuf_timestamp_column?(key)
-          column_types = _protobuf_column_types[:timestamp]
-          !column_types.nil? && column_types.include?(key)
+          _protobuf_column_types[:timestamp].include?(key)
         end
       end
     end

--- a/lib/protobuf/active_record/columns.rb
+++ b/lib/protobuf/active_record/columns.rb
@@ -1,10 +1,13 @@
 require 'set'
 require 'active_support/concern'
+require 'thread'
 
 module Protobuf
   module ActiveRecord
     module Columns
       extend ::ActiveSupport::Concern
+
+      COLUMN_TYPE_MAP_MUTEX = ::Mutex.new
 
       included do
         include ::Heredity
@@ -40,7 +43,7 @@ module Protobuf
         # Map out the columns for future reference on type conversion
         # :nodoc:
         def _protobuf_map_columns(force = false)
-          ::Thread.exclusive do
+          COLUMN_TYPE_MAP_MUTEX.synchronize do
             @_protobuf_mapped_columns = false if force
 
             return unless table_exists?

--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -21,20 +21,10 @@ module Protobuf
       module ClassMethods
         # :nodoc:
         def _protobuf_convert_attributes_to_fields(key, value)
-          case
-          when value.nil? then
-            value
-          when _protobuf_date_column?(key) then
-            value.to_time(:utc).to_i
-          when _protobuf_datetime_column?(key) then
-            value.to_i
-          when _protobuf_time_column?(key) then
-            value.to_i
-          when _protobuf_timestamp_column?(key) then
-            value.to_i
-          else
-            value
-          end
+          return value unless _protobuf_date_datetime_time_or_timestamp_column?(key)
+          return value.to_time(:utc).to_i if _protobuf_date_column?(key)
+
+          value.to_i
         end
 
         def _protobuf_field_options

--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -22,9 +22,9 @@ module Protobuf
         # :nodoc:
         def _protobuf_convert_attributes_to_fields(key, value)
           return value unless _protobuf_date_datetime_time_or_timestamp_column?(key)
-          return value.to_time(:utc).to_i if _protobuf_date_column?(key)
+          return value.to_i unless _protobuf_date_column?(key)
 
-          value.to_i
+          value.to_time(:utc).to_i
         end
 
         def _protobuf_field_options

--- a/lib/protobuf/active_record/transformation.rb
+++ b/lib/protobuf/active_record/transformation.rb
@@ -62,6 +62,8 @@ module Protobuf
           return value if value.nil?
 
           value = case
+                  when !_protobuf_date_datetime_time_or_timestamp_column?(key) then
+                    value
                   when _protobuf_date_column?(key) then
                     convert_int64_to_date(value)
                   when _protobuf_datetime_column?(key) then

--- a/spec/protobuf/active_record/columns_spec.rb
+++ b/spec/protobuf/active_record/columns_spec.rb
@@ -23,7 +23,9 @@ describe Protobuf::ActiveRecord::Columns do
       end
 
       it "maps column names by column type" do
-        expect(User._protobuf_column_types).to eq expected_column_types
+        expected_column_types.each do |expected_column_type, value|
+          expect(User._protobuf_column_types).to include expected_column_type => value
+        end
       end
     end
   end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -76,13 +76,10 @@ describe Protobuf::ActiveRecord::Serialization do
 
   describe ".field_from_record" do
     context "when the given converter is a symbol" do
-      let(:callable) { lambda { |value| User.__send__(:extract_first_name) } }
-
       before { User.field_from_record :first_name, :extract_first_name }
 
-      it "creates a callable method object from the converter" do
-        expect(User).to receive(:extract_first_name)
-        User._protobuf_field_transformers[:first_name].call(1)
+      it "creates a symbol transformer from the converter" do
+        expect(User._protobuf_field_symbol_transformers[:first_name]).to eq :extract_first_name
       end
     end
 

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -13,7 +13,10 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:date) { Date.new(2015, 10, 1) }
       let(:integer) { 1_443_657_600 }
 
-      before { allow(User).to receive(:_protobuf_date_column?).and_return(true) }
+      before {
+        allow(User).to receive(:_protobuf_date_datetime_time_or_timestamp_column?).and_return(true)
+        allow(User).to receive(:_protobuf_date_column?).and_return(true)
+      }
 
       it "converts the given value to an integer" do
         expect(User._protobuf_convert_attributes_to_fields(:foo_date, date)).to eq integer
@@ -24,7 +27,10 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:datetime) { DateTime.current }
       let(:integer) { datetime.to_time.to_i }
 
-      before { allow(User).to receive(:_protobuf_datetime_column?).and_return(true) }
+      before {
+        allow(User).to receive(:_protobuf_date_datetime_time_or_timestamp_column?).and_return(true)
+        allow(User).to receive(:_protobuf_datetime_column?).and_return(true)
+      }
 
       it "converts the given value to an integer" do
         expect(User._protobuf_convert_attributes_to_fields(:foo_datetime, datetime)).to eq integer
@@ -35,7 +41,10 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:time) { Time.current }
       let(:integer) { time.to_time.to_i }
 
-      before { allow(User).to receive(:_protobuf_time_column?).and_return(true) }
+      before {
+        allow(User).to receive(:_protobuf_date_datetime_time_or_timestamp_column?).and_return(true)
+        allow(User).to receive(:_protobuf_time_column?).and_return(true)
+      }
 
       it "converts the given value to an integer" do
         expect(User._protobuf_convert_attributes_to_fields(:foo_time, time)).to eq integer
@@ -46,7 +55,10 @@ describe Protobuf::ActiveRecord::Serialization do
       let(:timestamp) { Time.current }
       let(:integer) { timestamp.to_time.to_i }
 
-      before { allow(User).to receive(:_protobuf_timestamp_column?).and_return(true) }
+      before {
+        allow(User).to receive(:_protobuf_date_datetime_time_or_timestamp_column?).and_return(true)
+        allow(User).to receive(:_protobuf_timestamp_column?).and_return(true)
+      }
 
       it "converts the given value to an integer" do
         expect(User._protobuf_convert_attributes_to_fields(:foo_timestamp, timestamp)).to eq integer

--- a/spec/protobuf/active_record/transformation_spec.rb
+++ b/spec/protobuf/active_record/transformation_spec.rb
@@ -34,7 +34,10 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:date) { Date.current }
       let(:value) { date.to_time.to_i }
 
-      before { allow(User).to receive(:_protobuf_date_column?).and_return(true) }
+      before {
+        allow(User).to receive(:_protobuf_date_datetime_time_or_timestamp_column?).and_return(true)
+        allow(User).to receive(:_protobuf_date_column?).and_return(true)
+      }
 
       it "converts the given value to a Date object" do
         expect(User._protobuf_convert_fields_to_attributes(:foo_date, value)).to eq date
@@ -45,7 +48,10 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:datetime) { DateTime.current }
       let(:value) { datetime.to_i }
 
-      before { allow(User).to receive(:_protobuf_datetime_column?).and_return(true) }
+      before {
+        allow(User).to receive(:_protobuf_date_datetime_time_or_timestamp_column?).and_return(true)
+        allow(User).to receive(:_protobuf_datetime_column?).and_return(true)
+      }
 
       it "converts the given value to a DateTime object" do
         expect(User._protobuf_convert_fields_to_attributes(:foo_datetime, value)).to be_a(DateTime)
@@ -60,7 +66,10 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:time) { Time.current }
       let(:value) { time.to_i }
 
-      before { allow(User).to receive(:_protobuf_time_column?).and_return(true) }
+      before {
+        allow(User).to receive(:_protobuf_date_datetime_time_or_timestamp_column?).and_return(true)
+        allow(User).to receive(:_protobuf_time_column?).and_return(true)
+      }
 
       it "converts the given value to a Time object" do
         expect(User._protobuf_convert_fields_to_attributes(:foo_time, value)).to be_a(Time)
@@ -75,7 +84,10 @@ describe Protobuf::ActiveRecord::Transformation do
       let(:time) { Time.current }
       let(:value) { time.to_i }
 
-      before { allow(User).to receive(:_protobuf_timestamp_column?).and_return(true) }
+      before {
+        allow(User).to receive(:_protobuf_date_datetime_time_or_timestamp_column?).and_return(true)
+        allow(User).to receive(:_protobuf_timestamp_column?).and_return(true)
+      }
 
       it "converts the given value to a Time object" do
         expect(User._protobuf_convert_fields_to_attributes(:foo_time, value)).to be_a(Time)


### PR DESCRIPTION
1. Remove the `Thread::exclusive` in favor of `Mutex`
2. Add a Set that tracks date/datetime/time/timestamp as they are "exceptions" in the serialization flow
3. Only run column symbolization once on the mapping
4. Only fetch values during type check once (instead of fetch => [])
5. Check for `date` colums last as they are least frequent
6. Check for non-date/datetime/time/timestamp columns first as they are most frequent

@liveh2o @film42 