### PR TITLE
remove respond_to as call will fail without our check

### DIFF
--- a/lib/protobuf/active_record/scope.rb
+++ b/lib/protobuf/active_record/scope.rb
@@ -95,10 +95,6 @@ module Protobuf
           searchable_fields.each do |field, scope_name|
             next unless proto.respond_to_and_has_and_present?(field)
 
-            unless self.respond_to?(scope_name)
-              raise SearchScopeError, "Undefined scope :#{scope_name}."
-            end
-
             search_values = parse_search_values(proto, field)
             search_relation = search_relation.__send__(scope_name, *search_values)
           end

--- a/spec/protobuf/active_record/scope_spec.rb
+++ b/spec/protobuf/active_record/scope_spec.rb
@@ -42,7 +42,7 @@ describe Protobuf::ActiveRecord::Scope do
 
       it "raises an exception" do
         allow(User).to receive(:searchable_fields).and_return({ :email =>  :by_hullabaloo })
-        expect { User.search_scope(request) }.to raise_exception(/Undefined scope :by_hullabaloo/)
+        expect { User.search_scope(request) }.to raise_exception(/undefined method .*by_hullabaloo/i)
       end
     end
   end


### PR DESCRIPTION
a missing scope will fail anyway and the `respond_to` lookup on an ActiveRecord model is long

if we want to catch it and raise the SearchScopeError we should use a `rescue` as this is the exceptional state

@liveh2o 