### PR TITLE
use thread local connection and single lookup in query cache middleware

### DIFF
--- a/lib/protobuf/active_record/middleware/query_cache.rb
+++ b/lib/protobuf/active_record/middleware/query_cache.rb
@@ -1,3 +1,5 @@
+require "thread"
+
 module Protobuf
   module ActiveRecord
     module Middleware

--- a/lib/protobuf/active_record/middleware/query_cache.rb
+++ b/lib/protobuf/active_record/middleware/query_cache.rb
@@ -2,26 +2,28 @@ module Protobuf
   module ActiveRecord
     module Middleware
       class QueryCache
+        CURRENT_CONNECTION = "_protobuf_active_record_current_connection".freeze
+
         def initialize(app)
           @app = app
         end
 
         def call(env)
-          enabled = ::ActiveRecord::Base.connection.query_cache_enabled
-          connection_id = ::ActiveRecord::Base.connection_id
-          ::ActiveRecord::Base.connection.enable_query_cache!
+          connection = ::Thread.current[CURRENT_CONNECTION] = ::Activerecord::Base.connection
+          enabled = connection.query_cache_enabled
+          connection.enable_query_cache!
 
           @app.call(env)
         ensure
-          restore_query_cache_settings(connection_id, enabled)
+          restore_query_cache_settings(enabled)
         end
 
       private
 
-        def restore_query_cache_settings(connection_id, enabled)
-          ::ActiveRecord::Base.connection_id = connection_id
-          ::ActiveRecord::Base.connection.clear_query_cache
-          ::ActiveRecord::Base.connection.disable_query_cache! unless enabled
+        def restore_query_cache_settings(enabled)
+          ::Thread.current[CURRENT_CONNECTION].clear_query_cache
+          ::Thread.current[CURRENT_CONNECTION].disable_query_cache! unless enabled
+          ::Thread.current[CURRENT_CONNECTION] = nil
         end
       end
     end


### PR DESCRIPTION
`ActiveRecord::Base.connection` triggers a lock to lookup the current connection, we know we are working with a single connection on a single request so we can store the connection in thread local space and avoid pool locks when directly interacting with the connection we need

this popped up on the profiling runs as a place to optimize all rpc service calls

@liveh2o @film42 @brianstien 