### PR TITLE
add concurrent ruby and make connection mgmt async with new middleware

### DIFF
--- a/lib/protobuf-activerecord.rb
+++ b/lib/protobuf-activerecord.rb
@@ -13,6 +13,7 @@ end
 
 require 'protobuf/active_record/config'
 require 'protobuf/active_record/middleware/connection_management'
+require 'protobuf/active_record/middleware/connection_management_async'
 require 'protobuf/active_record/middleware/query_cache'
 require 'protobuf/active_record/model'
 require 'protobuf/active_record/version'

--- a/lib/protobuf/active_record/config.rb
+++ b/lib/protobuf/active_record/config.rb
@@ -5,8 +5,8 @@ module Protobuf
         super
 
         self[:autoload] = true
-        self[:async_execution_interval] = 6
-        self[:async_timeout_interval] = 5
+        self[:connection_reaping_interval] = 6
+        self[:connection_reaping_timeout_interval] = 5
       end
     end
   end

--- a/lib/protobuf/active_record/config.rb
+++ b/lib/protobuf/active_record/config.rb
@@ -5,6 +5,8 @@ module Protobuf
         super
 
         self[:autoload] = true
+        self[:async_execution_interval] = 6
+        self[:async_timeout_interval] = 5
       end
     end
   end

--- a/lib/protobuf/active_record/middleware/connection_management_async.rb
+++ b/lib/protobuf/active_record/middleware/connection_management_async.rb
@@ -1,0 +1,50 @@
+require "concurrent"
+require "thread"
+
+module Protobuf
+  module ActiveRecord
+    module Middleware
+      class ConnectionManagementAsync
+        START_MUTEX = ::Mutex.new
+
+        def self.start_timed_task!
+          if timed_task_started.false?
+            START_MUTEX.synchronize do
+              return if timed_task_started.true?
+
+              timed_task = ::Concurrent::TimerTask.new(:execution_interval => 6, :timeout_interval => 5) do
+                ::ActiveRecord::Base.clear_active_connections!
+              end
+
+              timed_task.execute
+              timed_task_started.make_true
+            end
+          end
+        end
+
+        def self.timed_task_started
+          if @timed_task_started.nil?
+            @timed_task_started = ::Concurrent::AtomicBoolean.new(false)
+          end
+
+          @timed_task_started
+        end
+
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          def call(env)
+            @app.call(env)
+          end
+
+          self.class.start_timed_task!
+          call(env)
+        end
+
+        timed_task_started
+      end
+    end
+  end
+end

--- a/lib/protobuf/active_record/middleware/connection_management_async.rb
+++ b/lib/protobuf/active_record/middleware/connection_management_async.rb
@@ -12,8 +12,10 @@ module Protobuf
             START_MUTEX.synchronize do
               return if timed_task_started.true?
 
-              timed_task = ::Concurrent::TimerTask.new(:execution_interval => ::Protobuf::ActiveRecord.config.async_execution_interval,
-                                                       :timeout_interval => ::Protobuf::ActiveRecord.config.async_timeout_interval) do
+              timed_task = ::Concurrent::TimerTask.new(
+                             :execution_interval => ::Protobuf::ActiveRecord.config.connection_reaping_interval,
+                             :timeout_interval => ::Protobuf::ActiveRecord.config.connection_reaping_timeout_interval) do
+
                 ::ActiveRecord::Base.clear_active_connections!
               end
 

--- a/lib/protobuf/active_record/middleware/connection_management_async.rb
+++ b/lib/protobuf/active_record/middleware/connection_management_async.rb
@@ -12,7 +12,8 @@ module Protobuf
             START_MUTEX.synchronize do
               return if timed_task_started.true?
 
-              timed_task = ::Concurrent::TimerTask.new(:execution_interval => 6, :timeout_interval => 5) do
+              timed_task = ::Concurrent::TimerTask.new(:execution_interval => ::Protobuf::ActiveRecord.config.async_execution_interval,
+                                                       :timeout_interval => ::Protobuf::ActiveRecord.config.async_timeout_interval) do
                 ::ActiveRecord::Base.clear_active_connections!
               end
 

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   #
   spec.add_dependency "activerecord", "~> 4.2"
   spec.add_dependency "activesupport", ">= 3.2"
+  spec.add_dependency "concurrent-ruby"
   spec.add_dependency "heredity", ">= 0.1.1"
   spec.add_dependency "protobuf", ">= 3.0"
 


### PR DESCRIPTION
we found that async connection management improves throughput significantly because it is a locked data structure that was being accessed by many threads ... this introduces Concurrent Ruby Timed Task to take care of the resetting of connection state and allows it to be inserted as a middleware while keeping the default as the non-async version while we test it out

I am rewriting the `call` method on the instance after the first call because we only want the timed task to be started once .. the mutex will take care of it, but not having to check the AtomicBoolean for the state is a more optimized path; hence the rewriting of the call method after the first call

@liveh2o @mmmries @film42 @brianstien 