### PR TITLE
make class level symbol methods dispatch when it is private as well a…

### DIFF
--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -201,12 +201,20 @@ module Protobuf
         def _protobuf_write_symbol_transformer_method(field)
           transformer_method = _protobuf_field_symbol_transformers[field]
 
-          if self.methods.include?(transformer_method)
-            self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def _protobuf_active_record_serialize_#{field}
-                self.class.#{transformer_method}(self)
-              end
-            RUBY
+          if self.respond_to?(transformer_method, true)
+            if self.respond_to?(transformer_method, false)
+              self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def _protobuf_active_record_serialize_#{field}
+                  self.class.#{transformer_method}(self)
+                end
+              RUBY
+            else
+              self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def _protobuf_active_record_serialize_#{field}
+                  self.class.__send__(#{transformer_method}, self)
+                end
+              RUBY
+            end
           else
             self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
               def _protobuf_active_record_serialize_#{field}


### PR DESCRIPTION
…s public

backward compat prob from previous refactor ... we should look at warning on some of these paths as we probably want them to be all private or all public and all methods (not lambdas)

@film42 @liveh2o @brianstien 