### PR TITLE
default the Railtie to use Async ConnectionManagement

### DIFF
--- a/lib/protobuf/active_record/railtie.rb
+++ b/lib/protobuf/active_record/railtie.rb
@@ -11,7 +11,7 @@ module Protobuf
 
       ActiveSupport.on_load(:protobuf_rpc_service) do
         Protobuf::Rpc.middleware.insert_after Protobuf::Rpc::Middleware::Logger, Middleware::ConnectionManagement
-        Protobuf::Rpc.middleware.insert_after Middleware::ConnectionManagement, Middleware::QueryCache
+        Protobuf::Rpc.middleware.insert_after Middleware::ConnectionManagementAsync, Middleware::QueryCache
       end
     end
   end


### PR DESCRIPTION
now that we have been using this in prod, we should default to Async adapter in the railtie as it provides a significant performance boost

@liveh2o 