### PR TITLE
fix the default middleware setup to use async connection management

### DIFF
--- a/lib/protobuf/active_record/railtie.rb
+++ b/lib/protobuf/active_record/railtie.rb
@@ -10,7 +10,7 @@ module Protobuf
       end
 
       ActiveSupport.on_load(:protobuf_rpc_service) do
-        Protobuf::Rpc.middleware.insert_after Protobuf::Rpc::Middleware::Logger, Middleware::ConnectionManagement
+        Protobuf::Rpc.middleware.insert_after Protobuf::Rpc::Middleware::Logger, Middleware::ConnectionManagementAsync
         Protobuf::Rpc.middleware.insert_after Middleware::ConnectionManagementAsync, Middleware::QueryCache
       end
     end


### PR DESCRIPTION
Ran into a problem trying to use `3.4.0` because we can't `middleware.insert_after` for the async connection management when it isn't in the stack yet. Just a quick typo fix.

/cc @abrandoned 