### PR TITLE
Ensure we check connections in when done

### DIFF
--- a/lib/protobuf/active_record/middleware/connection_management_async.rb
+++ b/lib/protobuf/active_record/middleware/connection_management_async.rb
@@ -39,7 +39,9 @@ module Protobuf
 
         def call(env)
           def call(env)
-            @app.call(env)
+            ::ActiveRecord::Base.connection_pool.with_connection do
+              @app.call(env)
+            end
           end
 
           self.class.start_timed_task!


### PR DESCRIPTION
When we check a connection out from the connection pool, the connection
will be verified, and then the connection will be cached in the current
thread.  As long as the current thread is alive, this connection will
never be verified again.

In order to verify our connection on every request, we need to make sure
we check our connection back into the threadpool when we are done.  This
will force the next request that our thread handles to check out and
verify a connection from the pool.

If we fail to verify a connection before using it, we can potentially be
using a closed connection, which will result in an error.