### PR TITLE
Abrandoned/rescue name error

### DIFF
--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -151,6 +151,8 @@ module Protobuf
                   return nil if value.nil?
 
                   value.to_time(:utc).to_i
+                rescue NameError # Has happened when field is not on model or ignored from db
+                  return nil
                 end
               RUBY
             else
@@ -160,6 +162,8 @@ module Protobuf
                   return nil if value.nil?
 
                   value.to_i
+                rescue NameError # Has happened when field is not on model or ignored from db
+                  return nil
                 end
               RUBY
             end
@@ -167,6 +171,8 @@ module Protobuf
             self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
               def _protobuf_active_record_serialize_#{field}
                 #{field}
+              rescue NameError # Has happened when field is not on model or ignored from db
+                return nil
               end
             RUBY
           end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -166,6 +166,7 @@ describe Protobuf::ActiveRecord::Serialization do
         let(:fields_from_record) { { :guid => user.guid, :name => user.name, :email => user.email, :email_domain => nil, :password => nil, :nullify => nil } }
 
         before {
+          user.to_proto
           allow(user).to receive(:_protobuf_active_record_serialize_email_domain).and_return(nil)
         }
 


### PR DESCRIPTION
the "model" probs we were having with the `NameError` can be resolved with this patch ... basically if we define a field that isn't on the model then it will maintain the backward compat (if ignored or whatever)

still not sure of the exact way to replicate, but this will "solve" the problem

@liveh2o