### PR TITLE
Return a record instead of true/false for upsert

### DIFF
--- a/lib/protobuf/active_record/scope.rb
+++ b/lib/protobuf/active_record/scope.rb
@@ -178,12 +178,14 @@ module Protobuf
           record = for_upsert(proto)
           record.assign_attributes(proto)
           record.save
+          record
         end
 
         def upsert!(proto)
           record = for_upsert(proto)
           record.assign_attributes(proto)
           record.save!
+          record
         end
       end
     end

--- a/spec/protobuf/active_record/scope_spec.rb
+++ b/spec/protobuf/active_record/scope_spec.rb
@@ -193,9 +193,9 @@ describe Protobuf::ActiveRecord::Scope do
         expect(::User.first.email).to eq("bar")
       end
 
-      it "returns true when valid" do
+      it "returns a user" do
         result = ::User.upsert(proto)
-        expect(result).to be true
+        expect(result).to be_a(::User)
       end
     end
   end


### PR DESCRIPTION
The `upsert` method is not useful unless it returns the record. This makes `upsert` function similar to `create` rather than `update`.