### PR TITLE
add benchmark-ips and remove the need to write a new method on an obj…

### DIFF
--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -166,7 +166,12 @@ module Protobuf
 
           def call(selph)
             value = selph.__send__(@field)
-            value&.to_time(:utc)&.to_i
+
+            if value
+              value.to_time(:utc).to_i
+            else
+              nil
+            end
           rescue NameError # Has happened when field is not on model or ignored from db
             return nil
           end
@@ -179,7 +184,12 @@ module Protobuf
 
           def call(selph)
             value = selph.__send__(@field)
-            value&.to_i
+
+            if value
+              value.to_i
+            else
+              nil
+            end
           rescue NameError # Has happened when field is not on model or ignored from db
             return nil
           end
@@ -217,10 +227,9 @@ module Protobuf
         end
 
         class NilMethodCaller
-          def initialize(*args)
-          end
+          def initialize; end
 
-          def call(*args)
+          def call(selph)
             nil
           end
         end

--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -20,6 +20,10 @@ module Protobuf
       end
 
       module ClassMethods
+        def _protobuf_field_objects
+          @_protobuf_field_objects ||= {}
+        end
+
         def _protobuf_field_options
           @_protobuf_field_options ||= {}
         end
@@ -139,95 +143,105 @@ module Protobuf
           @protobuf_message
         end
 
-        def _protobuf_write_collection_assocation_method(field)
-          self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def _protobuf_active_record_serialize_#{field}
-              value = #{field}.to_a # Terminate the association
-            rescue NameError # Has happened when field is not on model or ignored from db
-              return nil
-            end
-          RUBY
+        class CollectionAssociationCaller
+          def initialize(method_name)
+            @method_name = method_name
+          end
+
+          def call(selph)
+            selph.__send__(@method_name).to_a
+          rescue NameError # Has happened when field is not on model or ignored from db
+            return nil
+          end
         end
 
-        def _protobuf_write_convert_to_fields_method(field)
+        def _protobuf_collection_association_object(field)
+          CollectionAssociationCaller.new(field)
+        end
+
+        class DateCaller
+          def initialize(field)
+            @field = field
+          end
+
+          def call(selph)
+            value = selph.__send__(@field)
+            value&.to_time(:utc)&.to_i
+          rescue NameError # Has happened when field is not on model or ignored from db
+            return nil
+          end
+        end
+
+        class DateTimeCaller
+          def initialize(field)
+            @field = field
+          end
+
+          def call(selph)
+            value = selph.__send__(@field)
+            value&.to_i
+          rescue NameError # Has happened when field is not on model or ignored from db
+            return nil
+          end
+        end
+
+        class NoConversionCaller
+          def initialize(field)
+            @field = field
+          end
+
+          def call(selph)
+            selph.__send__(@field)
+          rescue NameError # Has happened when field is not on model or ignored from db
+            return nil
+          end
+        end
+
+        def _protobuf_convert_to_fields_object(field)
           is_datetime_time_or_timestamp_column = _protobuf_date_datetime_time_or_timestamp_column?(field)
           is_date_column = _protobuf_date_column?(field)
 
           if is_datetime_time_or_timestamp_column
             if is_date_column
-              self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-                def _protobuf_active_record_serialize_#{field}
-                  value = #{field}
-                  return nil if value.nil?
-
-                  value.to_time(:utc).to_i
-                rescue NameError # Has happened when field is not on model or ignored from db
-                  return nil
-                end
-              RUBY
+              DateCaller.new(field)
             else
-              self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-                def _protobuf_active_record_serialize_#{field}
-                  value = #{field}
-                  return nil if value.nil?
-
-                  value.to_i
-                rescue NameError # Has happened when field is not on model or ignored from db
-                  return nil
-                end
-              RUBY
+              DateTimeCaller.new(field)
             end
           else
-            self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def _protobuf_active_record_serialize_#{field}
-                #{field}
-              rescue NameError # Has happened when field is not on model or ignored from db
-                return nil
-              end
-            RUBY
+            NoConversionCaller.new(field)
           end
         end
 
-        def _protobuf_write_field_transformer_method(field)
-          self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def _protobuf_active_record_serialize_#{field}
-              self.class._protobuf_field_transformers[:#{field}].call(self)
-            end
-          RUBY
+        def _protobuf_field_transformer_object(field)
+          _protobuf_field_transformers[field]
         end
 
-        def _protobuf_write_nil_method(field)
-          self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-            def _protobuf_active_record_serialize_#{field}
-              nil
-            end
-          RUBY
-        end
-
-        def _protobuf_write_symbol_transformer_method(field)
-          transformer_method = _protobuf_field_symbol_transformers[field]
-
-          if self.respond_to?(transformer_method, true)
-            if self.respond_to?(transformer_method, false)
-              self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-                def _protobuf_active_record_serialize_#{field}
-                  self.class.#{transformer_method}(self)
-                end
-              RUBY
-            else
-              self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-                def _protobuf_active_record_serialize_#{field}
-                  self.class.__send__(:#{transformer_method}, self)
-                end
-              RUBY
-            end
-          else
-            self.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-              def _protobuf_active_record_serialize_#{field}
-                #{transformer_method}
-              end
-            RUBY
+        class NilMethodCaller
+          def initialize(*args)
           end
+
+          def call(*args)
+            nil
+          end
+        end
+
+        def _protobuf_nil_object(field)
+          NilMethodCaller.new
+        end
+
+        class FieldSymbolTransformerCaller
+          def initialize(instance_class, method_name)
+            @instance_class = instance_class
+            @method_name = method_name
+          end
+
+          def call(selph)
+            @instance_class.__send__(@method_name, selph)
+          end
+        end
+
+        def _protobuf_symbol_transformer_object(field)
+          FieldSymbolTransformerCaller.new(self, _protobuf_symbol_transformer_object[field])
         end
       end
 
@@ -301,34 +315,32 @@ module Protobuf
         # in terms of optimization (`while` is slightly faster as no block carried through)
         while attribute_number < limit
           field = field_attributes[attribute_number]
-
-          begin
-            hash[field] = __send__("_protobuf_active_record_serialize_#{field}")
-          rescue NoMethodError => error
-            raise unless error.message =~ /_protobuf_active_record_serialize/i
-
-            case
-            when _protobuf_field_symbol_transformers.has_key?(field) then
-              self.class._protobuf_write_symbol_transformer_method(field)
-            when _protobuf_field_transformers.has_key?(field) then
-              self.class._protobuf_write_field_transformer_method(field)
-            when respond_to?(field) then
-              if _is_collection_association?(field)
-                self.class._protobuf_write_collection_assocation_method(field)
-              else
-                self.class._protobuf_write_convert_to_fields_method(field)
-              end
-            else
-              self.class._protobuf_write_nil_method(field)
-            end
-
-            hash[field] = __send__("_protobuf_active_record_serialize_#{field}")
-          end
-
+          field_object = _protobuf_field_objects(field)
+          hash[field] = field_object.call(self)
           attribute_number += 1
         end
 
         hash
+      end
+
+      # :nodoc:
+      def _protobuf_field_objects(field)
+        self.class._protobuf_field_objects[field] ||= begin
+          case
+          when _protobuf_field_symbol_transformers.has_key?(field) then
+            self.class._protobuf_symbol_transformer_object(field)
+          when _protobuf_field_transformers.has_key?(field) then
+            self.class._protobuf_field_transformer_object(field)
+          when respond_to?(field) then
+            if _is_collection_association?(field)
+              self.class._protobuf_collection_association_object(field)
+            else
+              self.class._protobuf_convert_to_fields_object(field)
+            end
+          else
+            self.class._protobuf_nil_object(field)
+          end
+        end
       end
 
       # :nodoc:

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   ##
   # Development dependencies
   #
+  spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.3.0"
   spec.add_development_dependency "rspec-pride", ">= 3.1.0"


### PR DESCRIPTION
…ect and use a hash of calling objects to perform the need

In doing a heap analysis of some of our memory issues lately I have come across issues in Jruby where adding singleton methods on objects during runtime cause problems (they seem to have issue being GC'd and yet aren't considered code) so we see many copies of these methods in the heap dumps we pull

https://github.com/jruby/jruby/issues/4968
https://github.com/jruby/jruby/issues/4391

I decided to rewrite the methods as just objects that take the same argument and respond to the same method `call` and therefore allow us to have a simple interface to any mechanism of conversion (and I'm guessing gets advantage of optimization because the caller objects are actually faster in benchmark-ips)

Have a few things to work through (like style) but wanted to get this up so everyone can see how when these are rewritten they can be optimized by the runtime better and hopefully stop leaking method definitions and symbols

@liveh2o @brianstien @film42 

Before applied
```
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)> Benchmark.ips do |x|
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)*   x.report("to_proto") {  
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)*     user.to_proto    
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)*   }    
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)* end  
Warming up --------------------------------------
            to_proto     2.999k i/100ms
Calculating -------------------------------------
            to_proto     30.743k (± 0.9%) i/s -    155.948k in   5.073046s
```

After applied
```
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)> Benchmark.ips do |x|
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)*   x.report("to_proto") {  
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)*     user.to_proto    
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)*   }    
[1] pry(#<RSpec::ExampleGroups::ProtobufActiveRecordSerialization::WhenProtobufMessageIsDefined::FieldsFromRecord::WhenATransformerIsDefinedForTheField>)* end  
Warming up --------------------------------------
            to_proto     3.247k i/100ms
Calculating -------------------------------------
            to_proto     33.329k (± 0.5%) i/s -    168.844k in   5.066105s
```