### PR TITLE
Rails 5.1

### DIFF
--- a/lib/protobuf/active_record/version.rb
+++ b/lib/protobuf/active_record/version.rb
@@ -1,5 +1,5 @@
 module Protobuf
   module ActiveRecord
-    VERSION = "5.0.0"
+    VERSION = "5.1.0.beta"
   end
 end

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-pride", ">= 3.1.0"
   spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "sqlite3", "~> 1.3.6"
+  spec.add_development_dependency "sqlite3", ">= 1.3"
   spec.add_development_dependency "timecop"
 end

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   ##
   # Dependencies
   #
-  spec.add_dependency "activerecord", "~> 5.0.0"
-  spec.add_dependency "activesupport", "~> 5.0.0"
+  spec.add_dependency "activerecord", "~> 5.1.0"
+  spec.add_dependency "activesupport", "~> 5.1.0"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "heredity", ">= 0.1.1"
   spec.add_dependency "protobuf", ">= 3.0"


### PR DESCRIPTION
Upgrade for Rails 5.1 compatibility. This didn't require any changes to the ActiveRecord integration, but  bumping the version makes it easier to align versions.

// @newellista