### PR TITLE
Upgrade to Rails 5.2

### DIFF
--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   ##
   # Dependencies
   #
-  spec.add_dependency "activerecord", "~> 5.1.0"
-  spec.add_dependency "activesupport", "~> 5.1.0"
+  spec.add_dependency "activerecord", "~> 5.2.0"
+  spec.add_dependency "activesupport", "~> 5.2.0"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "heredity", ">= 0.1.1"
   spec.add_dependency "protobuf", ">= 3.0"


### PR DESCRIPTION
Upgrade for Rails 5.2 compatibility. This didn't require any changes to the ActiveRecord integration, but bumping the version makes it easier to align versions.

// @newellista