### PR TITLE
Updates to Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 ---
 language: ruby
 rvm:
-  - 2.3
+  - 2.5

--- a/lib/protobuf/active_record/persistence.rb
+++ b/lib/protobuf/active_record/persistence.rb
@@ -50,6 +50,20 @@ module Protobuf
 
         super(attributes)
       end
+
+      # :nodoc:
+      def update(attributes)
+        attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
+
+        super(attributes)
+      end
+
+      # :nodoc:
+      def update!(attributes)
+        attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
+
+        super(attributes)
+      end
     end
   end
 end

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   ##
   # Dependencies
   #
-  spec.add_dependency "activerecord", "~> 5.2.0"
-  spec.add_dependency "activesupport", "~> 5.2.0"
+  spec.add_dependency "activerecord", "~> 6.0.0"
+  spec.add_dependency "activesupport", "~> 6.0.0"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "heredity", ">= 0.1.1"
   spec.add_dependency "protobuf", ">= 3.0"

--- a/spec/protobuf/active_record/persistence_spec.rb
+++ b/spec/protobuf/active_record/persistence_spec.rb
@@ -67,4 +67,28 @@ describe Protobuf::ActiveRecord::Persistence do
       user.update_attributes!(user_attributes)
     end
   end
+
+  describe "#update" do
+    it "accepts a protobuf message" do
+      expect_any_instance_of(User).to receive(:save)
+      user.update(proto)
+    end
+
+    it "accepts a hash" do
+      expect_any_instance_of(User).to receive(:save)
+      user.update(user_attributes)
+    end
+  end
+
+  describe "#update!" do
+    it "accepts a protobuf message" do
+      expect_any_instance_of(User).to receive(:save!)
+      user.update!(proto)
+    end
+
+    it "accepts a hash" do
+      expect_any_instance_of(User).to receive(:save!)
+      user.update!(user_attributes)
+    end
+  end
 end


### PR DESCRIPTION
This is a WIP upgrade to Rails 6.
Rails 6 has a deprecation warning for using `#update_attributes`.
I have included `#update` and `#update!` 