### PR TITLE
Add Rails 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 ---
 language: ruby
 rvm:
-  - 2.3
+  - 2.5

--- a/lib/protobuf/active_record/persistence.rb
+++ b/lib/protobuf/active_record/persistence.rb
@@ -38,6 +38,20 @@ module Protobuf
       end
 
       # :nodoc:
+      def update(attributes)
+        attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
+
+        super(attributes)
+      end
+
+      # :nodoc:
+      def update!(attributes)
+        attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
+
+        super(attributes)
+      end
+
+      # :nodoc:
       def update_attributes(attributes)
         attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
 

--- a/lib/protobuf/active_record/version.rb
+++ b/lib/protobuf/active_record/version.rb
@@ -1,5 +1,5 @@
 module Protobuf
   module ActiveRecord
-    VERSION = "5.2.0"
+    VERSION = "6.0.0"
   end
 end

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-pride", ">= 3.1.0"
   spec.add_development_dependency "pry-nav"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "sqlite3", ">= 1.3"
+  spec.add_development_dependency "sqlite3", ">= 1.4"
   spec.add_development_dependency "timecop"
 end

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |spec|
   ##
   # Dependencies
   #
-  spec.add_dependency "activerecord", "~> 5.2.0"
-  spec.add_dependency "activesupport", "~> 5.2.0"
+  spec.add_dependency "activerecord", "~> 6.0.0"
+  spec.add_dependency "activesupport", "~> 6.0.0"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "heredity", ">= 0.1.1"
   spec.add_dependency "protobuf", ">= 3.0"

--- a/spec/protobuf/active_record/persistence_spec.rb
+++ b/spec/protobuf/active_record/persistence_spec.rb
@@ -67,4 +67,28 @@ describe Protobuf::ActiveRecord::Persistence do
       user.update_attributes!(user_attributes)
     end
   end
+
+  describe "#update" do
+    it "accepts a protobuf message" do
+      expect_any_instance_of(User).to receive(:save)
+      user.update(proto)
+    end
+
+    it "accepts a hash" do
+      expect_any_instance_of(User).to receive(:save)
+      user.update(user_attributes)
+    end
+  end
+
+  describe "#update!" do
+    it "accepts a protobuf message" do
+      expect_any_instance_of(User).to receive(:save!)
+      user.update!(proto)
+    end
+
+    it "accepts a hash" do
+      expect_any_instance_of(User).to receive(:save!)
+      user.update!(user_attributes)
+    end
+  end
 end


### PR DESCRIPTION
This bumps the rails version to 6.0
Adds `#update` and `#update!` methods since `#update_attributes` and `#update_attributes!` will be deprecated in 6.1. 
Bumps ruby version to 2.5 as it is the minimum version for Rails 6.

Should I add a deprecation warning as well?
