### PR TITLE
Address deprecation warnings when using the nullify field

### DIFF
--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -225,8 +225,21 @@ module Protobuf
           end
         end
 
-        def _protobuf_nil_object(_field)
-          NilMethodCaller.new
+        class NilRepeatedMethodCaller
+          def initialize
+          end
+
+          def call(_selph)
+            []
+          end
+        end
+
+        def _protobuf_nil_object(field)
+          if field == :nullify
+            NilRepeatedMethodCaller.new
+          else
+            NilMethodCaller.new
+          end
         end
 
         class FieldSymbolTransformerCaller

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -187,9 +187,8 @@ describe Protobuf::ActiveRecord::Serialization do
     describe "#to_proto" do
       context "when a protobuf message is configured" do
         let(:proto) { protobuf_message.new(proto_hash) }
-        let(:proto_hash) { { :name => "foo" } }
-
-        before { allow(user).to receive(:fields_from_record).and_return(proto_hash) }
+        let(:proto_hash) { { :name => "foo ", :email => "test@test.com", :email_domain => "test.com" } }
+        let(:user) { User.new(:first_name => "foo", :email => "test@test.com") }
 
         it "intializes a new protobuf message with attributes from #to_proto_hash" do
           expect(user.to_proto).to eq proto


### PR DESCRIPTION
These changes resolve the following type of deprecation warnings:
`DEPRECATION WARNING: ['nullify']=nil is deprecated and will be removed from Protobuf 4.0 (use an empty array instead of nil) (called from to_proto at <file_path>)`

When using a protobuf message that includes a `nullify` field, calling `to_proto` on the ActiveRecord object when the `nullify` field has not been set will result in the deprecation warning. 

Because the specs around to_proto mocked the call to fields_from_record, this deprecation warning did not show up when running the specs. I modified the spec so the warning would show up, and then addressed the warning. (see photo)
![Screen Shot 2022-04-12 at 12 48 44 PM](https://user-images.githubusercontent.com/43584575/163033162-e3023989-0c94-4024-bb3a-22a093081fa6.png)

This change sets the proto `nullify` attribute to the empty array like the deprecation warning suggests. 

Specs after the change, no deprecation warning:
![Screen Shot 2022-04-12 at 12 53 52 PM](https://user-images.githubusercontent.com/43584575/163033468-a7ee3fc5-296a-4b18-8f32-a829d8410a0d.png)

