### PR TITLE
set nullify to empty array to address protobuf 4 deprecation warning

### DIFF
--- a/lib/protobuf/active_record/serialization.rb
+++ b/lib/protobuf/active_record/serialization.rb
@@ -225,6 +225,18 @@ module Protobuf
           end
         end
 
+        class EmptyNullifyCaller
+          def initialize; end
+
+          def call(_selph)
+            []
+          end
+        end
+
+        def _protobuf_empty_nullify_object(_field)
+          EmptyNullifyCaller.new
+        end
+
         def _protobuf_nil_object(_field)
           NilMethodCaller.new
         end
@@ -337,6 +349,8 @@ module Protobuf
             else
               self.class._protobuf_convert_to_fields_object(field)
             end
+          when field == :nullify
+            self.class._protobuf_empty_nullify_object(field)
           else
             self.class._protobuf_nil_object(field)
           end

--- a/spec/protobuf/active_record/serialization_spec.rb
+++ b/spec/protobuf/active_record/serialization_spec.rb
@@ -182,6 +182,21 @@ describe Protobuf::ActiveRecord::Serialization do
           expect(fields[:photos]).to be_an(Array)
         end
       end
+
+      context "when nullify is NOT an attribute" do
+        it "initializes nullify to empty array" do
+          expect(user.fields_from_record[:nullify]).to eq []
+        end
+      end
+
+      context "when nullify IS an attribute" do
+        let(:zero) { Zero.create(:nullify => true) }
+        before { Zero.protobuf_message(ZeroMessage) }
+
+        it "retains the original value" do
+          expect(zero.fields_from_record[:nullify]).to be true
+        end
+      end
     end
 
     describe "#to_proto" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,7 @@ RSpec.configure do |config|
   # Turn deprecation warnings into errors with full backtrace.
   config.raise_errors_for_deprecations!
 
-  # Verifies the existance of any stubbed methods, replaces better_receive and better_stub
+  # Verifies the existence of any stubbed methods, replaces better_receive and better_stub
   # https://www.relishapp.com/rspec/rspec-mocks/v/3-1/docs/verifying-doubles/partial-doubles
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true

--- a/spec/support/db/setup.rb
+++ b/spec/support/db/setup.rb
@@ -26,4 +26,9 @@ ActiveRecord::Schema.define(:version => 1) do
 
     t.timestamps :null => false
   end
+
+  create_table :zeros do |t|
+    t.boolean :nullify
+    t.integer :z_saber_level
+  end
 end

--- a/spec/support/definitions/messages.proto
+++ b/spec/support/definitions/messages.proto
@@ -21,3 +21,8 @@ message UserSearchMessage {
   repeated string guid = 1;
   repeated string email = 2;
 }
+
+message ZeroMessage {
+  bool nullify = 1;
+  int64 z_saber_level = 2;
+}

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -1,2 +1,3 @@
 require "support/models/photo"
 require "support/models/user"
+require "support/models/zero"

--- a/spec/support/models/zero.rb
+++ b/spec/support/models/zero.rb
@@ -1,0 +1,3 @@
+class Zero < ::ActiveRecord::Base
+  include ::Protobuf::ActiveRecord::Model
+end

--- a/spec/support/protobuf/messages.pb.rb
+++ b/spec/support/protobuf/messages.pb.rb
@@ -12,6 +12,7 @@ require 'protobuf'
 class PhotoMessage < ::Protobuf::Message; end
 class UserMessage < ::Protobuf::Message; end
 class UserSearchMessage < ::Protobuf::Message; end
+class ZeroMessage < ::Protobuf::Message; end
 
 
 ##
@@ -37,5 +38,10 @@ end
 class UserSearchMessage
   repeated :string, :guid, 1
   repeated :string, :email, 2
+end
+
+class ZeroMessage
+  optional :bool, :nullify, 1
+  optional :int64, :z_saber_level, 2
 end
 


### PR DESCRIPTION
Protobuf issues a deprecation warning about setting the `nullify` field to `nil` and instead suggests using an empty array:
```
DEPRECATION WARNING: ['nullify']=nil is deprecated and will be removed from Protobuf 4.0 (use an empty array instead of nil) (called from block in your_class at /Users/shaun.carlson/code/mail/spec/views/your_class_spec.rb:9)
```

So...I did that.  I also tried to handle for the case when it just so happens that an activerecord object defines a `nullify` attribute that this value still comes through.