### PR TITLE
Replace TravisCI with GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: "*"
+
+jobs:
+  lint:
+    name: Lint (Standard)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.7"
+          bundler-cache: true
+      - run: bundle exec standardrb --format github
+  test:
+    name: Specs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.7, head, jruby-9.4, jruby-head]
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: bundle install
+      - run: bundle exec rake spec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,3 @@
-require:
-  # Standard's config uses custom cops, so it must be loaded
-  - standard
-
+---
 inherit_gem:
-  standard: config/base.yml
-  standard-performance: config.base.yml
+  standard: config/ruby-2.7.yml

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,2 +1,3 @@
-parallel: true     # default: false
-ruby_version: 3.0  # default: RUBY_VERSION
+# For available configuration options, see:
+#   https://github.com/standardrb/standard
+format: progress # default: Standard::Formatter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
----
-language: ruby
-rvm:
-  - 2.5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+[![Build](https://github.com/liveh2o/protobuf-activerecord/actions/workflows/main.yml/badge.svg)](https://github.com/liveh2o/protobuf-activerecord/actions)
+[![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/standardrb/standard)
 [![Gem Version](https://badge.fury.io/rb/protobuf-activerecord.svg)](http://badge.fury.io/rb/protobuf-activerecord)
-[![Build Status](https://travis-ci.org/liveh2o/protobuf-activerecord.svg?branch=master)](https://travis-ci.org/liveh2o/protobuf-activerecord)
 
 # Protobuf ActiveRecord
 
@@ -170,11 +171,12 @@ end
 
 ### Setting attributes to nil
 
-The protocol buffers specification does not allow for the transport of 'null' or 'nil' values for a field.  In fact, in order to keep messages small and lightweight this is desireable behavior.  Fields are that are not set to a value will not be sent over the wire, but we cannot assume given a message has an absent value for a field that we should set the our attributes to nil.
+The protocol buffers specification does not allow for the transport of 'null' or 'nil' values for a field. In fact, in order to keep messages small and lightweight this is desireable behavior. Fields are that are not set to a value will not be sent over the wire, but we cannot assume given a message has an absent value for a field that we should set the our attributes to nil.
 
-In order to solve this problem, Protobuf::ActiveRecord has a convention that tells it when to set an attribute to nil.  A message must define a repeated string field named 'nullify'.  If an attribute has the same name as an element in the 'nullify' field, this attribute will be set to nil.
+In order to solve this problem, Protobuf::ActiveRecord has a convention that tells it when to set an attribute to nil. A message must define a repeated string field named 'nullify'. If an attribute has the same name as an element in the 'nullify' field, this attribute will be set to nil.
 
 Example:
+
 ```
 message UserMessage {
   optional string name = 1;
@@ -182,14 +184,16 @@ message UserMessage {
 }
 
 ```
+
 ```ruby
 m = UserMessage.new(:nullify => [:name])
 # When Protobuf::ActiveRecord maps this message, it will set the name attribute to nil overwriting any value that is set.
 ```
 
-For attribute transformers, the field name will not match the attribute name so we need to give the attribute transformer a hint to instruct it on how to nullify a given attribute.  When declaring an attribute transformer, you can specify a :nullify_on option.  This indicates for the given attribute, if the value of 'nullify_on' is present in the nullify field, set this attribute to nil.
+For attribute transformers, the field name will not match the attribute name so we need to give the attribute transformer a hint to instruct it on how to nullify a given attribute. When declaring an attribute transformer, you can specify a :nullify_on option. This indicates for the given attribute, if the value of 'nullify_on' is present in the nullify field, set this attribute to nil.
 
 Example:
+
 ```Ruby
 class User < ActiveRecord::Base
   # When 'account_guid' is present in the nullify array, our 'account_id' attribute will be set to nil

--- a/lib/protobuf/active_record/nested_attributes.rb
+++ b/lib/protobuf/active_record/nested_attributes.rb
@@ -37,7 +37,7 @@ module Protobuf
           end
         end
 
-        super(association_name, attributes_collection)
+        super
       end
 
       # :nodoc:
@@ -47,7 +47,7 @@ module Protobuf
           attributes = reflection.klass.attributes_from_proto(attributes)
         end
 
-        super(association_name, attributes)
+        super
       end
     end
   end

--- a/lib/protobuf/active_record/persistence.rb
+++ b/lib/protobuf/active_record/persistence.rb
@@ -10,14 +10,14 @@ module Protobuf
         def create(attributes = {}, &block)
           attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
 
-          super(attributes, &block)
+          super
         end
 
         # :nodoc:
         def create!(attributes = {}, &block)
           attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
 
-          super(attributes, &block)
+          super
         end
       end
 
@@ -27,28 +27,28 @@ module Protobuf
       def initialize(*args, &block)
         args[0] = attributes_from_proto(args.first) if args.first.is_a?(::Protobuf::Message)
 
-        super(*args, &block)
+        super
       end
 
       # :nodoc:
       def assign_attributes(attributes)
         attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
 
-        super(attributes)
+        super
       end
 
       # :nodoc:
       def update(attributes)
         attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
 
-        super(attributes)
+        super
       end
 
       # :nodoc:
       def update!(attributes)
         attributes = attributes_from_proto(attributes) if attributes.is_a?(::Protobuf::Message)
 
-        super(attributes)
+        super
       end
     end
   end


### PR DESCRIPTION
Add a CI action that runs lint and test jobs on pushes and pull requests to main, and remove unused TravisCi config.