### PR TITLE
Modernize the gem structure and setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,15 @@
-*.db
-*.gem
-.DS_Store
-.bundle
-.config
-.rvmrc
-.yardoc
-.ruby-*
-Gemfile.lock
-coverage
-pkg/*
-tmp
+/Gemfile.lock
+/.DS_Store
+/.bundle/
+/.ruby-*/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/spec/test.db
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Protobuf Active Record adheres to a shifted version of [semver](https://semver.org/spec/v2.0.0.html)
+(a la Rails): major/minor versions shadow Rails [versions](https://guides.rubyonrails.org/maintenance_policy.html#versioning)
+since it depends on specific Rails versions.
+
+## [Unreleased]
+
+## [7.0.0] – 2024-03-03
+
+- Added Rails 7.0 support

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,24 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in protobuf-activerecord.gemspec
 gemspec
+
+platforms :jruby do
+  gem "activerecord-jdbcsqlite3-adapter"
+end
+
+platforms :ruby do
+  gem "sqlite3", ">= 1.4"
+end
+
+gem "benchmark-ips"
+
+gem "rake", "~> 13.0"
+
+gem "rspec", "~> 3.0"
+gem "rspec-pride", ">= 3.1.0"
+
+gem "simplecov"
+
+gem "standard", "~> 1.3"
+
+gem "timecop"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,22 +1,21 @@
-Copyright (c) 2012 Adam Hutchison
+The MIT License (MIT)
 
-MIT License
+Copyright (c) 2024 Adam Hutchison
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Rakefile
+++ b/Rakefile
@@ -1,21 +1,22 @@
 require "bundler/gem_tasks"
 require "protobuf/tasks"
 require "rspec/core/rake_task"
-require "standard/rake"
 
 desc "Run specs"
-::RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec)
+
+require "standard/rake"
 
 desc "Run cops and specs (default)"
-task default: [:standard, :spec]
+task default: %i[spec standard:fix]
 
 desc "Remove protobuf definitions that have been compiled"
 task :clean do
-  ::FileUtils.rm(Dir.glob("spec/support/protobuf/**/*.proto"))
+  FileUtils.rm(Dir.glob("spec/support/protobuf/**/*.proto"))
   puts "Cleaned"
 end
 
 desc "Compile spec/support protobuf definitions"
 task :compile, [] => :clean do
-  ::Rake::Task["protobuf:compile"].invoke("", "spec/support/definitions", "spec/support/protobuf")
+  Rake::Task["protobuf:compile"].invoke("", "spec/support/definitions", "spec/support/protobuf")
 end

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "protobuf/active_record/version"
@@ -7,13 +9,28 @@ Gem::Specification.new do |spec|
   spec.version = Protobuf::ActiveRecord::VERSION
   spec.authors = ["Adam Hutchison"]
   spec.email = ["liveh2o@gmail.com"]
-  spec.homepage = "http://github.com/liveh2o/protobuf-activerecord"
+
   spec.summary = "Google Protocol Buffers integration for Active Record"
   spec.description = "Provides the ability to create Active Record objects from Protocol Buffer messages and vice versa."
+  spec.homepage = "http://github.com/liveh2o/protobuf-activerecord"
   spec.license = "MIT"
+  spec.required_ruby_version = ">= 2.7.0"
 
-  spec.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  spec.executables = spec.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = spec.homepage + "/blob/main/CHANGELOG.md"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  gemspec = File.basename(__FILE__)
+  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+    end
+  end
+  spec.bindir = "exe"
+  spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   ##
@@ -24,24 +41,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "heredity", ">= 0.1.1"
   spec.add_dependency "protobuf", ">= 3.0"
-
-  ##
-  # Development dependencies
-  #
-  spec.add_development_dependency "benchmark-ips"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", ">= 3.3.0"
-  spec.add_development_dependency "rspec-pride", ">= 3.1.0"
-  spec.add_development_dependency "pry-nav"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "standard"
-
-  if ENV["PLATFORM"] == "java" || ::RUBY_PLATFORM == "java"
-    spec.platform = "java"
-    spec.add_development_dependency "activerecord-jdbcsqlite3-adapter"
-  else
-    spec.add_development_dependency "sqlite3", ">= 1.4"
-  end
-
-  spec.add_development_dependency "timecop"
 end


### PR DESCRIPTION
Modernize the gem structure and setup to match that of fresh gem generated with Bundler:

    $ bundle gem protobuf-activerecord

including an updated license, and new changelog and code of conduct.

Also update the default rake task to fix Standard offenses.