### PR TITLE
Target Rails 7.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.7"
+          ruby-version: "3.1"
           bundler-cache: true
       - run: bundle exec standardrb --format github
   test:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, head, jruby-9.4, jruby-head]
+        ruby: [3.1, head, jruby-9.4, jruby-head]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 ---
 inherit_gem:
-  standard: config/ruby-2.7.yml
+  standard: config/ruby-3.1.yml

--- a/lib/protobuf/active_record/transformation.rb
+++ b/lib/protobuf/active_record/transformation.rb
@@ -120,7 +120,7 @@ module Protobuf
 
           if options[:nullify_on]
             field = protobuf_message.get_field(:nullify)
-            unless field&.is_a?(::Protobuf::Field::StringField) && field&.repeated?
+            unless field&.is_a?(::Protobuf::Field::StringField) && field.repeated?
               ::Protobuf::Logging.logger.warn "Message: #{protobuf_message} is not compatible with :nullify_on option"
             end
           end

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description = "Provides the ability to create Active Record objects from Protocol Buffer messages and vice versa."
   spec.homepage = "http://github.com/liveh2o/protobuf-activerecord"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -36,8 +36,8 @@ Gem::Specification.new do |spec|
   ##
   # Dependencies
   #
-  spec.add_dependency "activerecord", "~> 7.1.0"
-  spec.add_dependency "activesupport", "~> 7.1.0"
+  spec.add_dependency "activerecord", "~> 7.2.0"
+  spec.add_dependency "activesupport", "~> 7.2.0"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "heredity", ">= 0.1.1"
   spec.add_dependency "protobuf", ">= 3.0"


### PR DESCRIPTION
Rails 7.2 targets Ruby 3.1+. Update to Active Record and Active Support 7.2, and update the minimum Ruby version accordingly.