### PR TITLE
Fix connection handling, deprecation warnings

### DIFF
--- a/lib/protobuf/active_record/middleware/connection_management.rb
+++ b/lib/protobuf/active_record/middleware/connection_management.rb
@@ -9,7 +9,7 @@ module Protobuf
         def call(env)
           @app.call(env)
         ensure
-          ::ActiveRecord::Base.clear_active_connections!
+          ::ActiveRecord::Base.connection_handler.clear_active_connections!
         end
       end
     end

--- a/lib/protobuf/active_record/middleware/connection_management_async.rb
+++ b/lib/protobuf/active_record/middleware/connection_management_async.rb
@@ -16,7 +16,7 @@ module Protobuf
                 timeout_interval: ::Protobuf::ActiveRecord.config.connection_reaping_timeout_interval
               }
               timed_task = ::Concurrent::TimerTask.new(args) do
-                ::ActiveRecord::Base.clear_active_connections!
+                ::ActiveRecord::Base.connection_handler.clear_active_connections!
               end
 
               timed_task.execute

--- a/spec/protobuf/active_record/middleware/connection_management_async_spec.rb
+++ b/spec/protobuf/active_record/middleware/connection_management_async_spec.rb
@@ -1,0 +1,107 @@
+require "spec_helper"
+
+RSpec.describe Protobuf::ActiveRecord::Middleware::ConnectionManagementAsync do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(env) { env } }
+  let(:timer_task) { instance_double(Concurrent::TimerTask) }
+
+  before do
+    allow(Concurrent::TimerTask).to receive(:new).and_return(timer_task)
+    allow(timer_task).to receive(:execute)
+  end
+
+  after do
+    described_class.instance_variable_set(:@timed_task_started, nil)
+  end
+
+  describe ".timed_task_started" do
+    it "returns an AtomicBoolean" do
+      expect(described_class.timed_task_started).to be_a(Concurrent::AtomicBoolean)
+    end
+
+    it "defaults to false" do
+      expect(described_class.timed_task_started).to be_false
+    end
+  end
+
+  describe ".start_timed_task!" do
+    it "creates a TimerTask with configured intervals" do
+      expect(Concurrent::TimerTask).to receive(:new).with(
+        hash_including(
+          execution_interval: Protobuf::ActiveRecord.config.connection_reaping_interval,
+          timeout_interval: Protobuf::ActiveRecord.config.connection_reaping_timeout_interval
+        )
+      )
+      described_class.start_timed_task!
+    end
+
+    it "executes the timer task" do
+      expect(timer_task).to receive(:execute)
+      described_class.start_timed_task!
+    end
+
+    it "marks the task as started" do
+      described_class.start_timed_task!
+      expect(described_class.timed_task_started).to be_true
+    end
+
+    it "clears active connections on each tick" do
+      ActiveRecord::Base.connection
+      expect(ActiveRecord::Base.connection_pool.active_connection?).to be_truthy
+
+      allow(Concurrent::TimerTask).to receive(:new) do |*args, &block|
+        block.call
+        timer_task
+      end
+      described_class.start_timed_task!
+
+      expect(ActiveRecord::Base.connection_pool.active_connection?).to be_falsy
+    end
+
+    it "is idempotent" do
+      described_class.start_timed_task!
+      expect(Concurrent::TimerTask).not_to receive(:new)
+      described_class.start_timed_task!
+    end
+
+    it "is thread-safe via a mutex" do
+      expect(described_class::START_MUTEX).to receive(:synchronize)
+      described_class.start_timed_task!
+    end
+  end
+
+  describe "#call" do
+    it "invokes the app" do
+      expect(app).to receive(:call).with(:env).and_call_original
+      middleware.call(:env)
+    end
+
+    it "wraps the app call in a connection from the pool" do
+      expect(ActiveRecord::Base.connection_pool).to receive(:with_connection).and_call_original
+      middleware.call(:env)
+    end
+
+    context "on subsequent invocations" do
+      before do
+        first = described_class.new(->(env) { env })
+        first.call(:env)
+      end
+
+      it "does not call start_timed_task! again" do
+        expect(described_class).not_to receive(:start_timed_task!)
+        middleware.call(:env)
+      end
+
+      it "invokes the app" do
+        expect(app).to receive(:call).with(:env).and_call_original
+        middleware.call(:env)
+      end
+
+      it "wraps the app call in a connection from the pool" do
+        expect(ActiveRecord::Base.connection_pool).to receive(:with_connection).and_call_original
+        middleware.call(:env)
+      end
+    end
+  end
+end

--- a/spec/protobuf/active_record/middleware/connection_management_spec.rb
+++ b/spec/protobuf/active_record/middleware/connection_management_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe Protobuf::ActiveRecord::Middleware::ConnectionManagement do
+  subject(:middleware) { described_class.new(app) }
+
+  let(:app) { ->(env) { env } }
+
+  describe "#call" do
+    it "calls the app" do
+      expect(app).to receive(:call).with(:env)
+      middleware.call(:env)
+    end
+
+    it "releases checked-out connections after the call" do
+      ActiveRecord::Base.connection
+      expect(ActiveRecord::Base.connection_pool.active_connection?).to be_truthy
+
+      middleware.call(:env)
+
+      expect(ActiveRecord::Base.connection_pool.active_connection?).to be_falsy
+    end
+
+    it "releases checked-out connections even when the app raises" do
+      app = ->(_env) { raise "boom" }
+      middleware = described_class.new(app)
+
+      ActiveRecord::Base.connection
+      expect(ActiveRecord::Base.connection_pool.active_connection?).to be_truthy
+
+      expect { middleware.call(:env) }.to raise_error("boom")
+
+      expect(ActiveRecord::Base.connection_pool.active_connection?).to be_falsy
+    end
+  end
+end

--- a/spec/protobuf/active_record/middleware/query_cache_spec.rb
+++ b/spec/protobuf/active_record/middleware/query_cache_spec.rb
@@ -1,0 +1,61 @@
+require "spec_helper"
+
+RSpec.describe Protobuf::ActiveRecord::Middleware::QueryCache do
+  subject(:middleware) { described_class.new(app) }
+
+  describe "#call" do
+    it "calls the app" do
+      app = ->(env) { env }
+      expect(app).to receive(:call).with(:env)
+      described_class.new(app).call(:env)
+    end
+
+    it "enables query cache during the call and restores it after" do
+      ActiveRecord::Base.connection.disable_query_cache!
+      expect(ActiveRecord::Base.connection.query_cache_enabled).to be false
+
+      call_state = nil
+      app = ->(_env) { call_state = ActiveRecord::Base.connection.query_cache_enabled }
+      middleware = described_class.new(app)
+
+      middleware.call(:env)
+
+      expect(call_state).to be true
+      expect(ActiveRecord::Base.connection.query_cache_enabled).to be false
+    end
+
+    it "cleans up thread-local storage" do
+      middleware = described_class.new(->(env) { env })
+      middleware.call(:env)
+      expect(Thread.current[described_class::CURRENT_CONNECTION]).to be_nil
+    end
+
+    context "when query cache was already enabled" do
+      it "clears the cache but leaves it enabled" do
+        ActiveRecord::Base.connection.enable_query_cache!
+        expect(ActiveRecord::Base.connection.query_cache_enabled).to be true
+
+        call_state = nil
+        app = ->(_env) { call_state = ActiveRecord::Base.connection.query_cache_enabled }
+        middleware = described_class.new(app)
+
+        middleware.call(:env)
+
+        expect(call_state).to be true
+        expect(ActiveRecord::Base.connection.query_cache_enabled).to be true
+      end
+    end
+
+    it "restores settings even when the app raises" do
+      app = ->(_env) { raise "error" }
+      middleware = described_class.new(app)
+
+      ActiveRecord::Base.connection.disable_query_cache!
+      expect(ActiveRecord::Base.connection.query_cache_enabled).to be false
+
+      expect { middleware.call(:env) }.to raise_error("error")
+
+      expect(ActiveRecord::Base.connection.query_cache_enabled).to be false
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,10 @@ require "support/protobuf/messages.pb"
 # Silence protobuf"s logger
 Protobuf::Logging.logger.level = ::Logger::FATAL
 
+# TODO: Remove this when adding Rails 8.0 support
+# Opt-in to Rails 8.0 behavior now
+ActiveSupport.to_time_preserves_timezone = true
+
 RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 


### PR DESCRIPTION
Connection handling changed in Rails 7.1, and the old way of managing it is now deprecated:

> Rails 7.1: DEPRECATION WARNING: Calling `ActiveRecord::Base.clear_active_connections!` is deprecated. Please call the method directly on the connection handler; for example:
>
>     ActiveRecord::Base.connection_handler.clear_active_connections!

This wasn't caught when adding Rails 7.2 support because there were no specs for the middleware classes.

Update connection handling to use the new method instead of the deprecated one, and add specs for the middleware classes to catch changes like this in the future.

Also, Rails 8.0 preserves the timezone when calling to_time. Opt-in to the new behavior now in the spec helper.