### PR TITLE
Target Rails 8.0, Ruby 3.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
       - run: bundle exec standardrb --format github
   test:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.1, head, jruby-9.4, jruby-head]
+        ruby: [3.2, head, jruby-10.0, jruby-head]
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
       - uses: actions/checkout@v6

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 ---
 inherit_gem:
-  standard: config/ruby-3.1.yml
+  standard: config/ruby-3.2.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ since it depends on specific Rails versions.
 
 ## [Unreleased]
 
+- Added Rails 8.0 support
+- Require Ruby 3.2 or greater (to match Rails)
+
 ## [7.2.1] - 2026-06-14
 
 - Fix connection handling that was using a method deprecated in Rails 7.1

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,12 @@ source "https://rubygems.org"
 gemspec
 
 platforms :jruby do
-  gem "activerecord-jdbcsqlite3-adapter"
+  # Pre-release is required to run tests on JRuby
+  gem "activerecord-jdbcsqlite3-adapter", ">= 80.0.pre1"
 end
 
 platforms :ruby do
-  gem "sqlite3", ">= 1.4"
+  gem "sqlite3", ">= 2.9"
 end
 
 gem "benchmark-ips"

--- a/protobuf-activerecord.gemspec
+++ b/protobuf-activerecord.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description = "Provides the ability to create Active Record objects from Protocol Buffer messages and vice versa."
   spec.homepage = "http://github.com/liveh2o/protobuf-activerecord"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
@@ -36,8 +36,8 @@ Gem::Specification.new do |spec|
   ##
   # Dependencies
   #
-  spec.add_dependency "activerecord", "~> 7.2.0"
-  spec.add_dependency "activesupport", "~> 7.2.0"
+  spec.add_dependency "activerecord", "~> 8.0.0"
+  spec.add_dependency "activesupport", "~> 8.0.0"
   spec.add_dependency "concurrent-ruby"
   spec.add_dependency "heredity", ">= 0.1.1"
   spec.add_dependency "protobuf", ">= 3.0"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,9 +16,9 @@ require "support/protobuf/messages.pb"
 # Silence protobuf"s logger
 Protobuf::Logging.logger.level = ::Logger::FATAL
 
-# TODO: Remove this when adding Rails 8.0 support
-# Opt-in to Rails 8.0 behavior now
-ActiveSupport.to_time_preserves_timezone = true
+# TODO: Remove this when adding Rails 8.1 support
+# Opt-in to Rails 8.1 behavior now
+ActiveSupport.to_time_preserves_timezone = :zone
 
 RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers


### PR DESCRIPTION
Rails 8.0 targets Ruby 3.2+. Update to Active Record and Active Support 8.0, and update the minimum Ruby (and JRuby) version accordingly.

ARJDBC is not currently compatible with Rails 8.0, but there is a pre-release available. Update the Gemfile to use it so CI can run.